### PR TITLE
FLN: Nearby List Fix

### DIFF
--- a/indra/newview/llpanelpeople.cpp
+++ b/indra/newview/llpanelpeople.cpp
@@ -894,13 +894,31 @@ void LLPanelPeople::updateNearbyList()
 // [/RLVa:KB]
         LLWorld::getInstance()->getAvatars(&mNearbyList->getIDs(), &positions, gAgent.getPositionGlobal(), ALControlCache::NearMeRange);
 
+        int count_in_region = 0;
         LLViewerRegion* cur_region = gAgent.getRegion();
-        mNearbyCountText->setTextArg("[COUNT]", std::to_string(mNearbyList->size()));
 
-        if (cur_region)
+         if (!cur_region)
+         {
+            LL_WARNS() << "Current region is null" << LL_ENDL;
+            return;
+        }
+
+        // Iterate through avatars in the region.
+        // The nearby list reports the avatars in 4096m range (ALControlCache::NearMeRange)
+        // Reported UUIDs may not be in same region.
+        // Also the TOTAL changes based on your filter results --FLN
+        for (size_t i = 0; i < positions.size(); ++i)
         {
             mNearbyCountText->setTextArg("[REGION]", cur_region->getName());
+            if (cur_region->pointInRegionGlobal(positions[i]))
+            {
+                count_in_region++;
+            }
         }
+
+        mNearbyCountText->setTextArg("[TOTAL]", std::to_string(mNearbyList->size()));
+        mNearbyCountText->setTextArg("[COUNT]", std::to_string(count_in_region));
+        mNearbyCountText->setTextArg("[REGION]", RlvActions::canShowLocation() ? cur_region->getName() : "[REDACTED]");
 // [RLVa:KB] - Checked: RLVa-2.0.3
     }
     else

--- a/indra/newview/skins/default/xui/en/panel_people.xml
+++ b/indra/newview/skins/default/xui/en/panel_people.xml
@@ -184,7 +184,7 @@ Learn about [https://community.secondlife.com/knowledgebase/joining-and-particip
                use_ellipses="true"
                skip_link_underline="true"
                name="nearbycount">
-            There are [COUNT] avatars in [REGION].
+            There are [TOTAL] avatars total and [COUNT] in [REGION].
             </text>
          <layout_stack
            clip="false"


### PR DESCRIPTION
Fixed reporting so that it shows proper information.
The `mNearbyList` reports avatars in `ALControlCache::NearMeRange` (4096), some of those avatars may not be in the same region (Mainland as for example).
Created a counter of UUIDs in same region and reported those in the "query" information too.

## Mockup
![image](https://github.com/AlchemyViewer/Alchemy/assets/1794152/e9abed64-a189-4492-b9f9-de5ba9223ec5)


## Shoutout
Thank you @DarlCat for pointing this out. I mainly go to shopping events and my platform so I never noticed this issue.