### PR TITLE
FLN Auto Respond

### DIFF
--- a/indra/newview/app_settings/settings_per_account_alchemy.xml
+++ b/indra/newview/app_settings/settings_per_account_alchemy.xml
@@ -253,5 +253,49 @@
         <key>Value</key>
             <integer>0</integer>
         </map>
+    <key>AlchemyAutoresponseEnable</key>
+        <map>
+        <key>Comment</key>
+            <string>Automatically respond when someone messages you</string>
+        <key>Persist</key>
+            <integer>1</integer>
+        <key>Type</key>
+            <string>Boolean</string>
+        <key>Value</key>
+            <integer>0</integer>
+        </map>
+    <key>AlchemyAutoresponseNotFriendEnable</key>
+        <map>
+        <key>Comment</key>
+            <string>Automatically respond when someone messages you</string>
+        <key>Persist</key>
+            <integer>1</integer>
+        <key>Type</key>
+            <string>Boolean</string>
+        <key>Value</key>
+            <integer>0</integer>
+        </map>
+    <key>AlchemyAutoresponse</key>
+        <map>
+        <key>Comment</key>
+            <string>Auto response to instant messages.</string>
+        <key>Persist</key>
+            <integer>1</integer>
+        <key>Type</key>
+            <string>String</string>
+        <key>Value</key>
+            <string>This resident has turned on &apos;Autorespond mode&apos; like a boss.</string>
+        </map>
+    <key>AlchemyAutoresponseNotFriend</key>
+        <map>
+        <key>Comment</key>
+            <string>Auto response to instant messages to strangers. Stranger danger!</string>
+        <key>Persist</key>
+            <integer>1</integer>
+        <key>Type</key>
+            <string>String</string>
+        <key>Value</key>
+            <string>This resident has turned on &apos;Autorespond mode&apos; like a boss.</string>
+        </map>
   </map>
 </llsd>

--- a/indra/newview/app_settings/settings_per_account_alchemy.xml
+++ b/indra/newview/app_settings/settings_per_account_alchemy.xml
@@ -253,6 +253,17 @@
         <key>Value</key>
             <integer>0</integer>
         </map>
+        <key>AlchemyAutoresponseChanged</key>
+        <map>
+        <key>Comment</key>
+            <string>Does user's autoresponse response message differ from default?</string>
+        <key>Persist</key>
+            <integer>1</integer>
+        <key>Type</key>
+            <string>Boolean</string>
+        <key>Value</key>
+            <integer>0</integer>
+        </map>
     <key>AlchemyAutoresponseEnable</key>
         <map>
         <key>Comment</key>
@@ -285,6 +296,17 @@
             <string>String</string>
         <key>Value</key>
             <string>This resident has turned on &apos;Autorespond mode&apos; like a boss.</string>
+        </map>
+        <key>AlchemyAutoresponseNotFriendChanged</key>
+        <map>
+        <key>Comment</key>
+            <string>Does user's autoresponse not friend response message differ from default?</string>
+        <key>Persist</key>
+            <integer>1</integer>
+        <key>Type</key>
+            <string>Boolean</string>
+        <key>Value</key>
+            <integer>0</integer>
         </map>
     <key>AlchemyAutoresponseNotFriend</key>
         <map>

--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -444,6 +444,9 @@ LLAgent::LLAgent() :
     mShowAvatar(TRUE),
     mFrameAgent(),
 
+    mIsAutoRespond(false),
+    mIsAutoRespondNonFriends(false),
+    
     mIsDoNotDisturb(false),
     mIsRejectTeleportOffers(false),
     mIgnorePrejump(FALSE),
@@ -1798,6 +1801,42 @@ void LLAgent::selectRejectFriendshipRequests(BOOL selected)
 BOOL LLAgent::getRejectFriendshipRequests() const
 {
     return mIsRejectFriendshipRequests;
+}
+
+//-----------------------------------------------------------------------------
+// setAutoRespond()
+//-----------------------------------------------------------------------------
+void LLAgent::setAutoRespond(bool pIsAutoRespond)
+{
+    LL_INFOS() << "Setting autorespond mode to " << pIsAutoRespond << LL_ENDL;
+    mIsAutoRespond = pIsAutoRespond;
+    gSavedPerAccountSettings.setBOOL("AlchemyAutoresponseEnable", pIsAutoRespond);
+}
+
+//-----------------------------------------------------------------------------
+// getAutoRespond()
+//-----------------------------------------------------------------------------
+bool LLAgent::getAutoRespond() const
+{
+    return mIsAutoRespond;
+}
+
+//-----------------------------------------------------------------------------
+// setAutoRespondNonFriends()
+//-----------------------------------------------------------------------------
+void LLAgent::setAutoRespondNonFriends(bool pIsAutoRespondNonFriends)
+{
+    LL_INFOS() << "Setting AutoRespondingNonFriends mode to " << pIsAutoRespondNonFriends << LL_ENDL;
+    mIsAutoRespondNonFriends = pIsAutoRespondNonFriends;
+    gSavedPerAccountSettings.setBOOL("AlchemyAutoresponseNotFriendEnable", pIsAutoRespondNonFriends);
+}
+
+//-----------------------------------------------------------------------------
+// getAutoRespondNonFriends()
+//-----------------------------------------------------------------------------
+bool LLAgent::getAutoRespondNonFriends() const
+{
+    return mIsAutoRespondNonFriends;
 }
 
 //-----------------------------------------------------------------------------

--- a/indra/newview/llagent.h
+++ b/indra/newview/llagent.h
@@ -501,6 +501,18 @@ public:
 private:
     BOOL            mIsRejectFriendshipRequests;
 
+public:
+    void            setAutoRespond(bool pIsAutoRespond);
+    bool            getAutoRespond() const;
+private:
+    BOOL            mIsAutoRespond;
+
+public:
+    void            setAutoRespondNonFriends(bool pIsAutoRespondNonFriends);
+    bool            getAutoRespondNonFriends() const;
+private:
+    BOOL            mIsAutoRespondNonFriends;
+
     //--------------------------------------------------------------------
     // Grab
     //--------------------------------------------------------------------

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -489,6 +489,9 @@ BOOL LLFloaterPreference::postBuild()
         gSavedPerAccountSettings.setString("DoNotDisturbModeResponse", LLTrans::getString("DoNotDisturbModeResponseDefault"));
         gSavedPerAccountSettings.setString("ALRejectTeleportOffersResponse", LLTrans::getString("RejectTeleportOffersResponseDefault"));
         gSavedPerAccountSettings.setString("ALRejectFriendshipRequestsResponse", LLTrans::getString("RejectFriendshipRequestsResponseDefault"));
+
+        gSavedPerAccountSettings.setString("AlchemyAutoresponse", LLTrans::getString("AutoResponseModeDefault"));
+        gSavedPerAccountSettings.setString("AlchemyAutoresponseNotFriend", LLTrans::getString("AutoResponseModeNonFriendsDefault"));
     }
 
     // set 'enable' property for 'Clear log...' button
@@ -572,6 +575,24 @@ void LLFloaterPreference::onRejectTeleportOffersResponseChanged()
                     != getChild<LLUICtrl>("autorespond_rto_response")->getValue().asString();
 
     gSavedPerAccountSettings.setBOOL("ALRejectTeleportOffersResponseChanged", reject_teleport_offers_response_changed_flag);
+}
+
+void LLFloaterPreference::onAutoRespondResponseChanged()
+{
+    bool auto_response_changed_flag =
+            LLTrans::getString("AutoResponseModeDefault")
+                    != getChild<LLUICtrl>("autorespond_response")->getValue().asString();
+
+    gSavedPerAccountSettings.setBOOL("ALAutoRespondChanged", auto_response_changed_flag);
+}
+
+void LLFloaterPreference::onAutoRespondNonFriendsResponseChanged()
+{
+    bool auto_response_non_friends_changed_flag =
+            LLTrans::getString("AutoResponseModeNonFriendsDefault")
+                    != getChild<LLUICtrl>("autorespond_nf_response")->getValue().asString();
+
+    gSavedPerAccountSettings.setBOOL("ALAutoRespondNonFriendsChanged", auto_response_non_friends_changed_flag);
 }
 
 #if !LL_HAVOK
@@ -951,6 +972,9 @@ LLFloaterPreference::~LLFloaterPreference()
     mComplexityChangedSignal.disconnect();
     mDnDModeConnection.disconnect();
     mRejectTeleportConnection.disconnect();
+    mAutoResponseConnection.disconnect();
+    mAutoResponseNonFriendsConnection.disconnect();
+    // mAutoResponseAwayAvatarConnection.disconnect();
 }
 
 void LLFloaterPreference::draw()
@@ -1037,6 +1061,15 @@ void LLFloaterPreference::apply()
         }
     }
 
+    // Setting this up so we sync the settings with menu.
+    // i.e Checking the checkox form the Preferences will also check it in the menu.
+    // --FLN 
+    bool autoresponse_enabled = getChild<LLCheckBoxCtrl>("AlchemyAutoresponseEnable")->get();
+    bool autoresponse_notfriends_enabled = getChild<LLCheckBoxCtrl>("AlchemyAutoresponseNotFriendEnable")->get();
+  
+    gAgent.setAutoRespond(autoresponse_enabled);
+    gAgent.setAutoRespondNonFriends(autoresponse_notfriends_enabled);
+
     saveAvatarProperties();
 }
 
@@ -1113,6 +1146,17 @@ void LLFloaterPreference::onOpen(const LLSD& key)
 
         mRejectTeleportConnection =  gSavedPerAccountSettings.getControl("ALRejectTeleportOffersResponse")->getSignal()->connect(boost::bind(&LLFloaterPreference::onRejectTeleportOffersResponseChanged, this));
 
+        mAutoResponseConnection = gSavedPerAccountSettings.getControl("AlchemyAutoresponse")->getSignal()->connect(boost::bind(&LLFloaterPreference::onAutoRespondResponseChanged, this));
+        
+        mAutoResponseNonFriendsConnection = gSavedPerAccountSettings.getControl("AlchemyAutoresponseNotFriend")->getSignal()->connect(boost::bind(&LLFloaterPreference::onAutoRespondNonFriendsResponseChanged, this));
+
+        // mAutoResponseEnableConnection = gSavedPerAccountSettings.getControl("AlchemyAutoresponseEnable")->getSignal()->connect(boost::bind(&LLFloaterPreference::onAutoRespondResponseChanged, this));
+        
+        // mAutoResponseNonFriendsEnableConnection = gSavedPerAccountSettings.getControl("AlchemyAutoresponseNotFriendEnable")->getSignal()->connect(boost::bind(&LLFloaterPreference::onAutoRespondNonFriendsResponseChanged, this));
+        
+        // mAutoResponseFriendsEnableConnection = gSavedPerAccountSettings.getControl("AlchemyAutoresponseEnable")->getSignal()->connect(boost::bind(&LLFloaterPreference::onAutoRespondResponseChanged, this));
+
+        // mAutoResponseAwayAvatarConnection = gSavedPerAccountSettings.getControl("ALSendAwayAvatarResponse")->getSignal()->connect(boost::bind(&LLFloaterPreference::onAutoRespondAwayAvatarResponseChanged, this));
     }
     gAgent.sendAgentUserInfoRequest();
 

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -583,16 +583,16 @@ void LLFloaterPreference::onAutoRespondResponseChanged()
             LLTrans::getString("AutoResponseModeDefault")
                     != getChild<LLUICtrl>("autorespond_response")->getValue().asString();
 
-    gSavedPerAccountSettings.setBOOL("ALAutoRespondChanged", auto_response_changed_flag);
+    gSavedPerAccountSettings.setBOOL("AlchemyAutoresponseChanged", auto_response_changed_flag);
 }
 
 void LLFloaterPreference::onAutoRespondNonFriendsResponseChanged()
 {
     bool auto_response_non_friends_changed_flag =
             LLTrans::getString("AutoResponseModeNonFriendsDefault")
-                    != getChild<LLUICtrl>("autorespond_nf_response")->getValue().asString();
+                    != getChild<LLUICtrl>("AlchemyAutoresponseNotFriend")->getValue().asString();
 
-    gSavedPerAccountSettings.setBOOL("ALAutoRespondNonFriendsChanged", auto_response_non_friends_changed_flag);
+    gSavedPerAccountSettings.setBOOL("AlchemyAutoresponseNotFriendChanged", auto_response_non_friends_changed_flag);
 }
 
 #if !LL_HAVOK
@@ -1262,6 +1262,19 @@ void LLFloaterPreference::initDoNotDisturbResponse()
         if (!gSavedPerAccountSettings.getBOOL("ALRejectFriendshipRequestsChanged"))
         {
             gSavedPerAccountSettings.setString("ALRejectFriendshipRequestsResponse", LLTrans::getString("RejectFriendshipRequestsResponseDefault"));
+        }
+
+        // This is called on viewer init so we setup defaults
+        // not sure this is necessary anymore ???
+        // -- FLN
+        if (!gSavedPerAccountSettings.getBOOL("AlchemyAutoresponseChanged"))
+        {
+            gSavedPerAccountSettings.setString("AlchemyAutoresponse", LLTrans::getString("AlchemyAutoresponseDefault"));
+        }
+        
+        if (!gSavedPerAccountSettings.getBOOL("AlchemyAutoresponseNotFriendChanged"))
+        {
+            gSavedPerAccountSettings.setString("AlchemyAutoresponseNotFriend", LLTrans::getString("AlchemyAutoresponseNotFriendDefault"));
         }
     }
 

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -974,7 +974,6 @@ LLFloaterPreference::~LLFloaterPreference()
     mRejectTeleportConnection.disconnect();
     mAutoResponseConnection.disconnect();
     mAutoResponseNonFriendsConnection.disconnect();
-    // mAutoResponseAwayAvatarConnection.disconnect();
 }
 
 void LLFloaterPreference::draw()
@@ -1150,13 +1149,6 @@ void LLFloaterPreference::onOpen(const LLSD& key)
         
         mAutoResponseNonFriendsConnection = gSavedPerAccountSettings.getControl("AlchemyAutoresponseNotFriend")->getSignal()->connect(boost::bind(&LLFloaterPreference::onAutoRespondNonFriendsResponseChanged, this));
 
-        // mAutoResponseEnableConnection = gSavedPerAccountSettings.getControl("AlchemyAutoresponseEnable")->getSignal()->connect(boost::bind(&LLFloaterPreference::onAutoRespondResponseChanged, this));
-        
-        // mAutoResponseNonFriendsEnableConnection = gSavedPerAccountSettings.getControl("AlchemyAutoresponseNotFriendEnable")->getSignal()->connect(boost::bind(&LLFloaterPreference::onAutoRespondNonFriendsResponseChanged, this));
-        
-        // mAutoResponseFriendsEnableConnection = gSavedPerAccountSettings.getControl("AlchemyAutoresponseEnable")->getSignal()->connect(boost::bind(&LLFloaterPreference::onAutoRespondResponseChanged, this));
-
-        // mAutoResponseAwayAvatarConnection = gSavedPerAccountSettings.getControl("ALSendAwayAvatarResponse")->getSignal()->connect(boost::bind(&LLFloaterPreference::onAutoRespondAwayAvatarResponseChanged, this));
     }
     gAgent.sendAgentUserInfoRequest();
 

--- a/indra/newview/llfloaterpreference.h
+++ b/indra/newview/llfloaterpreference.h
@@ -127,7 +127,6 @@ protected:
     void onRejectTeleportOffersResponseChanged();
     void onAutoRespondResponseChanged();
     void onAutoRespondNonFriendsResponseChanged();
-    // void onAutoRespondAwayAvatarResponseChanged();
 
     // if the custom settings box is clicked
     void onChangeCustom();

--- a/indra/newview/llfloaterpreference.h
+++ b/indra/newview/llfloaterpreference.h
@@ -272,9 +272,6 @@ private:
     boost::signals2::connection mPreferredMaturityConnection;
     boost::signals2::connection mAutoResponseConnection;
     boost::signals2::connection mAutoResponseNonFriendsConnection;
-    // boost::signals2::connection mAutoResponseAwayAvatarConnection;
-    // boost::signals2::connection mAutoResponseEnableConnection;
-    // boost::signals2::connection mAutoResponseNonFriendsEnableConnection;
 
     bool mDnDInit = false;
 

--- a/indra/newview/llfloaterpreference.h
+++ b/indra/newview/llfloaterpreference.h
@@ -125,6 +125,10 @@ protected:
     // string differs from default after user changes.
     void onDoNotDisturbResponseChanged();
     void onRejectTeleportOffersResponseChanged();
+    void onAutoRespondResponseChanged();
+    void onAutoRespondNonFriendsResponseChanged();
+    // void onAutoRespondAwayAvatarResponseChanged();
+
     // if the custom settings box is clicked
     void onChangeCustom();
     void updateMeterText(LLUICtrl* ctrl);
@@ -267,6 +271,11 @@ private:
     boost::signals2::connection mRejectTeleportConnection;
     boost::signals2::connection mChatBubbleOpacityConnection;
     boost::signals2::connection mPreferredMaturityConnection;
+    boost::signals2::connection mAutoResponseConnection;
+    boost::signals2::connection mAutoResponseNonFriendsConnection;
+    // boost::signals2::connection mAutoResponseAwayAvatarConnection;
+    // boost::signals2::connection mAutoResponseEnableConnection;
+    // boost::signals2::connection mAutoResponseNonFriendsEnableConnection;
 
     bool mDnDInit = false;
 

--- a/indra/newview/llimprocessing.cpp
+++ b/indra/newview/llimprocessing.cpp
@@ -75,15 +75,15 @@
 // -- FLN
 std::string replace_wildcards(std::string input, const LLUUID& id, const std::string& name)
 {
-	boost::algorithm::replace_all(input, "#n", name);
-// disable boost::lexical_cast warning
-	LLSLURL slurl;
-	LLAgentUI::buildSLURL(slurl);
-	boost::algorithm::replace_all(input, "#r", slurl.getSLURLString());
+    boost::algorithm::replace_all(input, "#n", name);
+    // disable boost::lexical_cast warning
+    LLSLURL slurl;
+    LLAgentUI::buildSLURL(slurl);
+    boost::algorithm::replace_all(input, "#r", slurl.getSLURLString());
 
-	LLAvatarName av_name;
-	boost::algorithm::replace_all(input, "#d", LLAvatarNameCache::get(id, &av_name) ? av_name.getDisplayName() : name);
-	return input;
+    LLAvatarName av_name;
+    boost::algorithm::replace_all(input, "#d", LLAvatarNameCache::get(id, &av_name) ? av_name.getDisplayName() : name);
+    return input;
 }
 
 
@@ -556,7 +556,7 @@ void LLIMProcessing::processNewMessage(LLUUID from_id,
     // Resurrect AutoResponse from Alchemy Archive 
     // -- FLN
     static LLCachedControl<bool> sAutorespond(gSavedPerAccountSettings, "AlchemyAutoresponseEnable");
-	static LLCachedControl<bool> sAutorespondNonFriend(gSavedPerAccountSettings, "AlchemyAutoresponseNotFriendEnable");
+    static LLCachedControl<bool> sAutorespondNonFriend(gSavedPerAccountSettings, "AlchemyAutoresponseNotFriendEnable");
 
     chat.mMuted = is_muted;
     chat.mFromID = from_id;

--- a/indra/newview/llimprocessing.cpp
+++ b/indra/newview/llimprocessing.cpp
@@ -29,6 +29,7 @@
 #include "llimprocessing.h"
 
 #include "llagent.h"
+#include "llagentui.h"
 #include "llappviewer.h"
 #include "llavatarnamecache.h"
 #include "llfirstuse.h"
@@ -64,7 +65,27 @@
 #include "rlvui.h"
 // [/RLVa:KB]
 
+#include <boost/algorithm/string/predicate.hpp> // <alchemy/>
+#include <boost/algorithm/string/replace.hpp>
 #include "boost/lexical_cast.hpp"
+
+
+
+// Resurrect the Autorespond from the archive
+// -- FLN
+std::string replace_wildcards(std::string input, const LLUUID& id, const std::string& name)
+{
+	boost::algorithm::replace_all(input, "#n", name);
+// disable boost::lexical_cast warning
+	LLSLURL slurl;
+	LLAgentUI::buildSLURL(slurl);
+	boost::algorithm::replace_all(input, "#r", slurl.getSLURLString());
+
+	LLAvatarName av_name;
+	boost::algorithm::replace_all(input, "#d", LLAvatarNameCache::get(id, &av_name) ? av_name.getDisplayName() : name);
+	return input;
+}
+
 
 extern void on_new_message(const LLSD& msg);
 
@@ -532,6 +553,11 @@ void LLIMProcessing::processNewMessage(LLUUID from_id,
     BOOL is_linden = chat.mSourceType != CHAT_SOURCE_OBJECT &&
         LLMuteList::isLinden(name);
 
+    // Resurrect AutoResponse from Alchemy Archive 
+    // -- FLN
+    static LLCachedControl<bool> sAutorespond(gSavedPerAccountSettings, "AlchemyAutoresponseEnable");
+	static LLCachedControl<bool> sAutorespondNonFriend(gSavedPerAccountSettings, "AlchemyAutoresponseNotFriendEnable");
+
     chat.mMuted = is_muted;
     chat.mFromID = from_id;
     chat.mFromName = name;
@@ -625,6 +651,49 @@ void LLIMProcessing::processNewMessage(LLUUID from_id,
                 }
 
             }
+            else if (offline == IM_ONLINE
+            && (sAutorespond || (sAutorespondNonFriend && !is_friend))
+            && from_id.notNull() //not a system message
+            && to_id.notNull()) //not global message
+            {
+                buffer = message;
+                LL_DEBUGS("Messaging") << "process_improved_im: session_id( " << session_id << " ), from_id( " << from_id << " )" << LL_ENDL;
+                bool send_response = !gIMMgr->hasSession(session_id);
+                gIMMgr->addMessage(session_id,
+                    from_id,
+                    name,
+                    buffer,
+                    IM_OFFLINE == offline,
+                    LLStringUtil::null,
+                    dialog,
+                    parent_estate_id,
+                    region_id,
+                    position,
+                    true);
+                if (send_response)
+                {
+                    std::string my_name;
+                    LLAgentUI::buildFullname(my_name);
+                    std::string response = gSavedPerAccountSettings.getString(sAutorespondNonFriend && !is_friend
+                        ? "AlchemyAutoresponseNotFriend"
+                        : "AlchemyAutoresponse");
+                    response = replace_wildcards(response, from_id, name);
+                    pack_instant_message(
+                        gMessageSystem,
+                        gAgent.getID(),
+                        FALSE,
+                        gAgent.getSessionID(),
+                        from_id,
+                        my_name,
+                        response,
+                        IM_ONLINE,
+                        IM_DO_NOT_DISTURB_AUTO_RESPONSE,
+                        session_id);
+                    gAgent.sendReliableMessage();
+                    gIMMgr->addMessage(session_id, gAgent.getID(), my_name, LLTrans::getString("AutoresponsePrefix").append(response));
+                }
+            }
+
             else if (from_id.isNull())
             {
                 LLSD args;
@@ -733,6 +802,32 @@ void LLIMProcessing::processNewMessage(LLUUID from_id,
                     false,
                     0
                 );
+
+                // Resurrect Autorespond from Alchemy archive
+                // -- FLN
+                if (sAutorespond || (sAutorespondNonFriend && !is_friend))
+                {
+                    std::string my_name;
+                    LLAgentUI::buildFullname(my_name);
+                    std::string response = gSavedPerAccountSettings.getString(sAutorespondNonFriend && !is_friend
+                        ? "AlchemyAutoresponseNotFriend"
+                        : "AlchemyAutoresponse");
+                    response = replace_wildcards(response, from_id, name);
+                    pack_instant_message(gMessageSystem,
+                        gAgent.getID(),
+                        FALSE,
+                        gAgent.getSessionID(),
+                        from_id,
+                        my_name,
+                        response,
+                        IM_ONLINE,
+                        IM_DO_NOT_DISTURB_AUTO_RESPONSE,
+                        session_id);
+                    gAgent.sendReliableMessage();
+
+                    gIMMgr->addMessage(session_id, gAgent.getID(), my_name, LLTrans::getString("AutoresponsePrefix").append(response));
+                }
+
             }
 
             gIMMgr->processIMTypingStart(from_id, dialog);

--- a/indra/newview/llimprocessing.h
+++ b/indra/newview/llimprocessing.h
@@ -59,5 +59,11 @@ private:
     static void requestOfflineMessagesLegacy();
 };
 
+// Resurrect the Autorespond from the archive
+// -- FLN
+// Replace wild cards in message strings
+std::string replace_wildcards(std::string input, const LLUUID& id, const std::string& name);
+
+
 
 #endif  // LL_LLLLIMPROCESSING_H

--- a/indra/newview/llviewermenu.cpp
+++ b/indra/newview/llviewermenu.cpp
@@ -6587,6 +6587,56 @@ class LLWorldGetRejectFriendshipRequests : public view_listener_t
     }
 };
 
+class LLCommunicateSetAutoRespond : public view_listener_t
+{
+    bool handleEvent(const LLSD& userdata)
+    {
+        if (gAgent.getAutoRespond())
+        {
+            gAgent.setAutoRespond(false);
+        }
+        else
+        {
+            gAgent.setAutoRespond(true);
+            LLNotificationsUtil::add("AutoRespondModeSet");
+        }
+        return true;
+    }
+};
+
+class LLCommunicateCheckAutoRespond : public view_listener_t
+{
+    bool handleEvent(const LLSD& userdata)
+    {
+       return gAgent.getAutoRespond();
+    }
+};
+
+class LLCommunicateSetAutoRespondNonFriends : public view_listener_t
+{
+    bool handleEvent(const LLSD& userdata)
+    {
+        if (gAgent.getAutoRespondNonFriends())
+        {
+            gAgent.setAutoRespondNonFriends(false);
+        }
+        else
+        {
+            gAgent.setAutoRespondNonFriends(true);
+            LLNotificationsUtil::add("AutoRespondNonFriendsModeSet");
+        }
+        return true;
+    }
+};
+
+class LLCommunicateCheckAutoRespondNonFriends : public view_listener_t
+{
+    bool handleEvent(const LLSD& userdata)
+    {
+        return gAgent.getAutoRespondNonFriends();
+    }
+};
+
 class LLWorldCreateLandmark : public view_listener_t
 {
     bool handleEvent(const LLSD& userdata)
@@ -10089,6 +10139,13 @@ void initialize_menus()
 
     //Communicate Nearby chat
     view_listener_t::addMenu(new LLCommunicateNearbyChat(), "Communicate.NearbyChat");
+
+     // Communicate > Autorespond
+    view_listener_t::addMenu(new LLCommunicateSetAutoRespond(), "Communicate.SetAutoRespond");
+    view_listener_t::addMenu(new LLCommunicateSetAutoRespondNonFriends(), "Communicate.SetAutoRespondNonFriends");
+    view_listener_t::addMenu(new LLCommunicateCheckAutoRespond(), "Communicate.GetAutoRespond");
+    view_listener_t::addMenu(new LLCommunicateCheckAutoRespondNonFriends(), "Communicate.GetAutoRespondNonFriends");
+
 
     // Communicate > Voice morphing > Subscribe...
     commit.add("Communicate.VoiceMorphing.Subscribe", boost::bind(&handle_voice_morphing_subscribe));

--- a/indra/newview/skins/default/xui/en/menu_viewer.xml
+++ b/indra/newview/skins/default/xui/en/menu_viewer.xml
@@ -729,8 +729,24 @@
              function="World.GetRejectFriendshipRequests"/>
           <menu_item_check.on_click
               function="World.SetRejectFriendshipRequests"/>
- </menu_item_check>
-
+      </menu_item_check>
+      <menu_item_separator/>
+      <menu_item_check
+         label="Autorespond"
+         name="Set AutoRespond">
+            <menu_item_check.on_check
+            function="Communicate.GetAutoRespond"/>
+            <menu_item_check.on_click
+            function="Communicate.SetAutoRespond"/>
+      </menu_item_check>
+      <menu_item_check
+         label="AutoRespond to non-friends"
+         name="Set AutoRespond to non-friends">
+            <menu_item_check.on_check
+            function="Communicate.GetAutoRespondNonFriends"/>
+            <menu_item_check.on_click
+            function="Communicate.SetAutoRespondNonFriends"/>
+      </menu_item_check>
     </menu>
     <menu
      create_jump_keys="true"

--- a/indra/newview/skins/default/xui/en/notifications.xml
+++ b/indra/newview/skins/default/xui/en/notifications.xml
@@ -13318,4 +13318,27 @@ C:\Users\USERNAME\AppData\Roaming\AlchemyNext\user_settings\animations
       name="okbutton"
       yestext="OK"/>
   </notification>
+  <notification
+   icon="alert.tga"
+   name="AutoRespondModeSet"
+   type="alert">
+Autorespond mode is on.
+Incoming instant messages will now be answered with your configured autoresponse.
+    <usetemplate
+     ignoretext="I change my status to autorespond mode"
+     name="okignore"
+     yestext="OK"/>
+  </notification>
+
+    <notification
+   icon="alert.tga"
+   name="AutoRespondNonFriendsModeSet"
+   type="alert">
+Autorespond mode for non-friends is on.
+Incoming instant messages from anyone who is not your friend will now be answered with your configured autoresponse.
+    <usetemplate
+     ignoretext="I change my status to autorespond mode for non-friends"
+     name="okignore"
+     yestext="OK"/>
+  </notification>
 </notifications>

--- a/indra/newview/skins/default/xui/en/panel_preferences_chat.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_chat.xml
@@ -32,6 +32,12 @@
 				layout="topleft"
 				follows="top|left" />
             <panel
+				label="Reject Messages"
+				name="chat_pref_moderation"
+				filename="panel_preferences_chat_rejection.xml"
+				layout="topleft"
+				follows="top|left" />
+            <panel
 				label="Autoresponse"
 				name="chat_pref_autoresponse"
 				filename="panel_preferences_chat_autoresponse.xml"

--- a/indra/newview/skins/default/xui/en/panel_preferences_chat_autoresponse.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_chat_autoresponse.xml
@@ -76,7 +76,7 @@
      top_pad="5"
      follows="left|top"
      height="16"
-     label="Autorespond to new instant messages from non-friends (uses the designated message)"
+     label="Autorespond to new instant messages from non-friends"
      left="10"
      name="AlchemyAutoresponseNotFriendEnable"
      width="270"

--- a/indra/newview/skins/default/xui/en/panel_preferences_chat_autoresponse.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_chat_autoresponse.xml
@@ -7,67 +7,79 @@
     left="13"
     width="517">
       <text
-        top_pad="20"
-        follow="left|top"
-        height="18"
-        type="string"
-        length="1"
-        layout="topleft"
-        left="15"
-        name="autorespond_reject_friends_response_label"
-        width="500">
-        Automatic response to all avatars when in REJECT FRIENDSHIP REQUESTS mode
+         type="string"
+         length="1"
+         follows="left|top"
+         height="13"
+         layout="topleft"
+         left="15"
+         mouse_opaque="false"
+         name="autorespond_response_label"
+         top_pad="10"
+         width="475">
+           Automatic response to all avatars when in AUTORESPONSE to everyone mode:
         </text>
         <text_editor
-          control_name="ALRejectFriendshipRequestsResponse"
-          use_ellipses="false"
-          commit_on_focus_lost="true"
-          follows="left|top"
-          height="55"
-          layout="topleft"
-          left="15"
-          top_pad="5"
-          name="autorespond_reject_friends_response"
-          width="475"
-          word_wrap="true">
-          log_in_to_change
+         enabled_control="AlchemyAutoresponseEnable"
+         control_name="AlchemyAutoresponse"
+         use_ellipses="false"
+         commit_on_focus_lost = "true"
+         follows="left|top"
+         height="45"
+         layout="topleft"
+         left="15"
+         top_pad="10"
+         name="AlchemyAutoresponse"
+         width="475"
+         word_wrap="true">
+           log_in_to_change
         </text_editor>
 
-      <text
-        top_pad="15"
-        follows="left|top"
-        height="18"
-        type="string"
-        length="1"
-        layout="topleft"
-        left="15"
-        name="autorespond_rto_response_label"
-        mouse_opaque="false"
-        width="500">
-        Automatic response to all avatars when in REJECT TELEPORT OFFERS mode:
+        <text
+         type="string"
+         length="1"
+         follows="left|top"
+         height="13"
+         layout="topleft"
+         left="15"
+         mouse_opaque="false"
+         name="autorespond_nf_response_label"
+         top_pad="10"
+         width="475">
+           Automatic response to non-friends when in AUTORESPONSE TO NON-FRIENDS mode:
         </text>
-      <text_editor
-        control_name="ALRejectTeleportOffersResponse"
-        use_ellipses="false"
-        commit_on_focus_lost = "true"
-        follows="left|top"
-        text_readonly_color="LabelDisabledColor"
-        bg_writeable_color="LtGray"
-        height="45"
-        layout="topleft"
-        left="15"
-        name="autorespond_rto_response"
-        width="475"
-        word_wrap="true">
-          log_in_to_change
+        <text_editor
+        enabled_control="AlchemyAutoresponseNotFriendEnable"
+         control_name="AlchemyAutoresponseNotFriend"
+         use_ellipses="false"
+         commit_on_focus_lost = "true"
+         follows="left|top"
+         height="45"
+         layout="topleft"
+         left="15"
+         top_pad="10"
+         name="AlchemyAutoresponseNotFriend"
+         width="475"
+         word_wrap="true">
+           log_in_to_change
         </text_editor>
-        <check_box
-          top_pad="5"
-          left="15"
-          follows="left|top"
-          height="16"
-          label="Don't reject teleport offers (and send response) from people on friends list"
-          name="ALDontRejectTeleportOffersFromFriends"
-          width="500"
-          control_name="ALDontRejectTeleportOffersFromFriends" />
+    <check_box
+     top_pad="5"
+     follows="left|top"
+     height="16"
+     label="Autorespond to new instant messages from anyone"
+     left="10"
+     name="AlchemyAutoresponseEnable"
+     width="270"
+     control_name="AlchemyAutoresponseEnable"/>
+    <check_box
+     top_pad="5"
+     follows="left|top"
+     height="16"
+     label="Autorespond to new instant messages from non-friends (uses the designated message)"
+     left="10"
+     name="AlchemyAutoresponseNotFriendEnable"
+     width="270"
+     control_name="AlchemyAutoresponseNotFriendEnable"/>
+
     </panel>

--- a/indra/newview/skins/default/xui/en/panel_preferences_chat_rejection.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_chat_rejection.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<panel
+    height="408"
+    layout="topleft"
+    name="autoresponse_settings"
+    top="0"
+    left="13"
+    width="517">
+      <text
+        top_pad="20"
+        follow="left|top"
+        height="18"
+        type="string"
+        length="1"
+        layout="topleft"
+        left="15"
+        name="autorespond_reject_friends_response_label"
+        width="500">
+        Automatic response to all avatars when in REJECT FRIENDSHIP REQUESTS mode
+        </text>
+        <text_editor
+          control_name="ALRejectFriendshipRequestsResponse"
+          use_ellipses="false"
+          commit_on_focus_lost="true"
+          follows="left|top"
+          height="55"
+          layout="topleft"
+          left="15"
+          top_pad="5"
+          name="autorespond_reject_friends_response"
+          width="475"
+          word_wrap="true">
+          log_in_to_change
+        </text_editor>
+
+      <text
+        top_pad="15"
+        follows="left|top"
+        height="18"
+        type="string"
+        length="1"
+        layout="topleft"
+        left="15"
+        name="autorespond_rto_response_label"
+        mouse_opaque="false"
+        width="500">
+        Automatic response to all avatars when in REJECT TELEPORT OFFERS mode:
+        </text>
+      <text_editor
+        control_name="ALRejectTeleportOffersResponse"
+        use_ellipses="false"
+        commit_on_focus_lost = "true"
+        follows="left|top"
+        text_readonly_color="LabelDisabledColor"
+        bg_writeable_color="LtGray"
+        height="45"
+        layout="topleft"
+        left="15"
+        name="autorespond_rto_response"
+        width="475"
+        word_wrap="true">
+          log_in_to_change
+        </text_editor>
+        <check_box
+          top_pad="5"
+          left="15"
+          follows="left|top"
+          height="16"
+          label="Don't reject teleport offers (and send response) from people on friends list"
+          name="ALDontRejectTeleportOffersFromFriends"
+          width="500"
+          control_name="ALDontRejectTeleportOffersFromFriends" />
+    </panel>

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -2858,7 +2858,11 @@ If you continue to receive this message, please contact Second Life support for 
   <!-- panel preferences general -->
   <string name="DoNotDisturbModeResponseDefault">This resident has turned on &apos;Do Not Disturb&apos; and will see your message later.</string>
   <string name="RejectFriendshipRequestsResponseDefault">The Resident you messaged has activated [APP_NAME] viewer&apos;s &apos;reject all friendship requests mode&apos; which means they have requested not to be disturbed with friendship requests. You may still send an IM manually.</string>
+
+  <!-- panel preferences chat-->
   <string name="RejectTeleportOffersResponseDefault">The Resident you messaged has activated [APP_NAME] viewer&apos;s &apos;reject all teleport offers and requests mode&apos; which means they have requested not to be disturbed with teleport offers and requests. You may still send an IM message manually.</string>
+  <string name="AutoResponseModeDefault">The Resident you messaged has activated [APP_NAME] viewer&apos;s &apos;autorespond mode&apos; which means they have requested not to be disturbed.  Your message will still be shown in their IM panel for later viewing.</string>
+  <string name="AutoResponseModeNonFriendsDefault">The Resident you messaged has activated [APP_NAME] viewer&apos;s &apos;autorespond mode&apos; which means they have requested not to be disturbed.  Your message will still be shown in their IM panel for later viewing.</string>
 
 	<!-- Mute -->
 	<string name="MuteByName">(By name)</string>

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -2861,8 +2861,8 @@ If you continue to receive this message, please contact Second Life support for 
 
   <!-- panel preferences chat-->
   <string name="RejectTeleportOffersResponseDefault">The Resident you messaged has activated [APP_NAME] viewer&apos;s &apos;reject all teleport offers and requests mode&apos; which means they have requested not to be disturbed with teleport offers and requests. You may still send an IM message manually.</string>
-  <string name="AutoResponseModeDefault">The Resident you messaged has activated [APP_NAME] viewer&apos;s &apos;autorespond mode&apos; which means they have requested not to be disturbed.  Your message will still be shown in their IM panel for later viewing.</string>
-  <string name="AutoResponseModeNonFriendsDefault">The Resident you messaged has activated [APP_NAME] viewer&apos;s &apos;autorespond mode&apos; which means they have requested not to be disturbed.  Your message will still be shown in their IM panel for later viewing.</string>
+  <string name="AutoResponseModeDefault">The Resident you messaged has activated &apos;autorespond mode&apos; which means they have requested not to be disturbed.  Your message will still be shown in their IM panel for later viewing.</string>
+  <string name="AutoResponseModeNonFriendsDefault">The Resident you messaged has activated &apos;autorespond non-friends mode&apos; which means they have requested not to be disturbed.  Your message will still be shown in their IM panel for later viewing.</string>
 
 	<!-- Mute -->
 	<string name="MuteByName">(By name)</string>

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -2861,8 +2861,8 @@ If you continue to receive this message, please contact Second Life support for 
 
   <!-- panel preferences chat-->
   <string name="RejectTeleportOffersResponseDefault">The Resident you messaged has activated [APP_NAME] viewer&apos;s &apos;reject all teleport offers and requests mode&apos; which means they have requested not to be disturbed with teleport offers and requests. You may still send an IM message manually.</string>
-  <string name="AutoResponseModeDefault">The Resident you messaged has activated &apos;autorespond mode&apos; which means they have requested not to be disturbed.  Your message will still be shown in their IM panel for later viewing.</string>
-  <string name="AutoResponseModeNonFriendsDefault">The Resident you messaged has activated &apos;autorespond non-friends mode&apos; which means they have requested not to be disturbed.  Your message will still be shown in their IM panel for later viewing.</string>
+  <string name="AlchemyAutoresponseDefault">The Resident you messaged has activated &apos;autorespond mode&apos; which means they have requested not to be disturbed.  Your message will still be shown in their IM panel for later viewing.</string>
+  <string name="AlchemyAutoresponseNotFriendDefault">The Resident you messaged has activated &apos;autorespond non-friends mode&apos; which means they have requested not to be disturbed.  Your message will still be shown in their IM panel for later viewing.</string>
 
 	<!-- Mute -->
 	<string name="MuteByName">(By name)</string>

--- a/indra/newview/skins/default/xui/en/strings.xml
+++ b/indra/newview/skins/default/xui/en/strings.xml
@@ -3735,6 +3735,7 @@ Please reinstall viewer from https://alchemyviewer.org/downloads and contact the
   <string name="OfflineStatus">Offline</string>
 	<string name="not_online_msg">User not online - message will be stored and delivered later.</string>
 	<string name="not_online_inventory">User not online - inventory has been saved.</string>
+	<string name="AutoresponsePrefix">(Autoresponse)</string>
 
 	<!-- voice calls -->
 	<string name="answered_call">Your call has been answered</string>


### PR DESCRIPTION
## Add Auto Response

As a resident, I would like the ability to have 3 types of autoresponses

Incoming instant message on "autorespond" mode will send a reply to a user (regardless if friend or not) with a configured message from the preference window

Incoming instant message on "autorespond non-friends" mode will send a reply to user (only if not a friend) with a configured message from the preference window 


### Acceptance Criteria
* [x] AC 1. - On incoming message from anyone with "autorespond mode", send configured message 
* [x] AC 2. - On incoming message from someone not on friend's list with "autorespond non-friends" mode, send configured message


#### Conditions

* [x] Friend receives message if "autorespond" enabled 
* [x] Stranger receives message if "autorespond" enabled
* [x] Stranger receives message if "autorespond nonfriend" enabled, but friends do ot.
* [x] Friend and Stranger receives different messages if "autorespond" and "autorespond nonfriend"  enabled and on friends list

## Mockups
![image](https://github.com/AlchemyViewer/Alchemy/assets/1794152/3ba55854-e8be-426b-9d68-508ae0abaa39)
![image](https://github.com/AlchemyViewer/Alchemy/assets/1794152/0ab3437c-9e50-4f32-9efb-90fe8ce0c70c)
![image](https://github.com/AlchemyViewer/Alchemy/assets/1794152/fe91fca2-06fa-499d-b544-817ead500fce)
