### PR TITLE
ALCH-185-fix-autorespond use correct setting

### DIFF
--- a/indra/newview/llagent.cpp
+++ b/indra/newview/llagent.cpp
@@ -537,8 +537,8 @@ void LLAgent::init()
 
     selectRejectFriendshipRequests(gSavedPerAccountSettings.getBOOL("ALRejectFriendshipRequestsMode"));
     setRejectTeleportOffers(gSavedPerAccountSettings.getBOOL("ALRejectTeleportOffersMode"));
-    setAutoRespond(gSavedPerAccountSettings.getBOOL("AutoRespondModeSet"));
-    setAutoRespondNonFriends(gSavedPerAccountSettings.getBOOL("AutoRespondNonFriendsModeSet"));
+    setAutoRespond(gSavedPerAccountSettings.getBOOL("AlchemyAutoresponseEnable"));
+    setAutoRespondNonFriends(gSavedPerAccountSettings.getBOOL("AutoRespondNotFriendsEnable"));
 
 
     if (!mTeleportFinishedSlot.connected())


### PR DESCRIPTION
`AutoRespondModeSet` is for the notification not the setting. 
Correct settings are `AlchemyAutoresponseEnable` and `AutoRespondNotFriendsEnable`