### PR TITLE
Add IRC-style chat colors options

### DIFF
--- a/indra/newview/alavatargroups.cpp
+++ b/indra/newview/alavatargroups.cpp
@@ -330,9 +330,13 @@ bool ALAvatarGroups::getIRCNameColor(const LLChat& chat, LLUIColor& color)
         return false;
     }
 
-    // Keep the default name styling while restricted from seeing this speaker's
-    // name, matching getIRCChatColor.
-    if (!RlvActions::canShowName(RlvActions::SNC_DEFAULT, chat.mFromID))
+    // Only override names for the same other-agent messages whose chat color is
+    // overridden by getIRCChatColor.
+    if (chat.mSourceType != CHAT_SOURCE_AGENT
+        || chat.mFromID.isNull()
+        || chat.mFromID == gAgentID
+        || chat.mFromName == SYSTEM_FROM
+        || !RlvActions::canShowName(RlvActions::SNC_DEFAULT, chat.mFromID))
     {
         return false;
     }

--- a/indra/newview/alavatargroups.cpp
+++ b/indra/newview/alavatargroups.cpp
@@ -322,7 +322,7 @@ bool ALAvatarGroups::getIRCChatColor(const LLChat& chat, LLUIColor& color)
     return false;
 }
 
-bool ALAvatarGroups::getIRCNameColor(const LLChat& chat, const LLUIColor& chat_color, LLUIColor& color)
+bool ALAvatarGroups::getIRCNameColor(const LLChat& chat, LLUIColor& color)
 {
     static LLCachedControl<bool> enabled(gSavedSettings, "AlchemyChatIRCColorsEnabled", false);
     if (!enabled)
@@ -337,7 +337,7 @@ bool ALAvatarGroups::getIRCNameColor(const LLChat& chat, const LLUIColor& chat_c
         return false;
     }
 
-    color = dimNameColor(chat_color.get());
+    color = nameColor(chat.mFromID);
     return true;
 }
 
@@ -353,11 +353,11 @@ bool ALAvatarGroups::getIRCNameTagColor(const LLUUID& id, LLColor4& color)
     // Mirror the chat-color override: only other agents get a per-avatar color,
     // self keeps the user-configured name tag colors. Skip while restricted from
     // seeing this avatar's name so the color can't defeat @shownames. The name
-    // dimming applied to chat names is applied here too so tags match.
+    // lightness applied to chat names is applied here too so tags match.
     if (id.notNull() && id != gAgentID
         && RlvActions::canShowName(RlvActions::SNC_DEFAULT, id))
     {
-        color = dimNameColor(deterministicAgentColor(id));
+        color = nameColor(id);
         return true;
     }
 
@@ -376,17 +376,18 @@ LLColor4 ALAvatarGroups::deterministicAgentColor(const LLUUID& id)
     return color;
 }
 
-LLColor4 ALAvatarGroups::dimNameColor(const LLColor4& color)
+LLColor4 ALAvatarGroups::nameColor(const LLUUID& id)
 {
-    static LLCachedControl<F32> scale(gSavedSettings, "AlchemyChatIRCNameLightnessScale", 0.8f);
+    static LLCachedControl<F32> saturation(gSavedSettings, "AlchemyChatIRCAgentSaturation", 0.7f);
+    static LLCachedControl<F32> name_lightness(gSavedSettings, "AlchemyChatIRCNameLightness", 0.7f);
 
-    F32 hue = 0.f;
-    F32 saturation = 0.f;
-    F32 lightness = 0.f;
-    color.calcHSL(&hue, &saturation, &lightness);
-
+    // Same hue and saturation as the per-agent chat color, but with the name's
+    // own independent lightness. Built from the same inputs as the chat color
+    // rather than derived from it, so the chat Lightness slider doesn't bleed
+    // into the name (a very light/dark chat color loses saturation, and hue at
+    // the extremes, when round-tripped through RGB).
     LLColor4 result;
-    result.setHSL(hue, saturation, lightness * scale());
+    result.setHSL(static_cast<F32>(id.getCRC32() % 360) / 360.f, saturation(), name_lightness());
     result.mV[VALPHA] = 1.f;
 
     return result;

--- a/indra/newview/alavatargroups.cpp
+++ b/indra/newview/alavatargroups.cpp
@@ -26,6 +26,7 @@
 // lib includes
 #include "llavatarname.h"
 #include "llavatarnamecache.h"
+#include "llchat.h"
 #include "lluicolor.h"
 #include "lluicolortable.h"
 #include "lluuid.h"
@@ -34,6 +35,7 @@
 // viewer includes
 #include "llagent.h"
 #include "llcallingcard.h"
+#include "llinstantmessage.h" // SYSTEM_FROM
 #include "llmutelist.h"
 #include "llviewercontrol.h"
 #include "rlvactions.h"
@@ -293,4 +295,99 @@ std::string ALAvatarGroups::getAvatarColorName(const LLUUID& id, std::string_vie
     }
 
     return out_color_name;
+}
+
+bool ALAvatarGroups::getIRCChatColor(const LLChat& chat, LLUIColor& color)
+{
+    static LLCachedControl<bool> enabled(gSavedSettings, "AlchemyChatIRCColorsEnabled", false);
+    if (!enabled)
+    {
+        return false;
+    }
+
+    // Only override "other" speakers; self, system, objects and owner-say keep
+    // their user-configured chat colors from the existing switch.
+    if (chat.mSourceType == CHAT_SOURCE_AGENT
+        && chat.mFromID.notNull()
+        && chat.mFromID != gAgentID
+        && SYSTEM_FROM != chat.mFromName
+        // A stable per-avatar color would defeat @shownames, so skip it while
+        // restricted from seeing this speaker's name.
+        && RlvActions::canShowName(RlvActions::SNC_DEFAULT, chat.mFromID))
+    {
+        color = deterministicAgentColor(chat.mFromID);
+        return true;
+    }
+
+    return false;
+}
+
+bool ALAvatarGroups::getIRCNameColor(const LLChat& chat, const LLUIColor& chat_color, LLUIColor& color)
+{
+    static LLCachedControl<bool> enabled(gSavedSettings, "AlchemyChatIRCColorsEnabled", false);
+    if (!enabled)
+    {
+        return false;
+    }
+
+    // Keep the default name styling while restricted from seeing this speaker's
+    // name, matching getIRCChatColor.
+    if (!RlvActions::canShowName(RlvActions::SNC_DEFAULT, chat.mFromID))
+    {
+        return false;
+    }
+
+    color = dimNameColor(chat_color.get());
+    return true;
+}
+
+bool ALAvatarGroups::getIRCNameTagColor(const LLUUID& id, LLColor4& color)
+{
+    static LLCachedControl<bool> enabled(gSavedSettings, "AlchemyChatIRCColorsEnabled", false);
+    static LLCachedControl<bool> name_tags(gSavedSettings, "AlchemyChatIRCColorNameTags", false);
+    if (!enabled || !name_tags)
+    {
+        return false;
+    }
+
+    // Mirror the chat-color override: only other agents get a per-avatar color,
+    // self keeps the user-configured name tag colors. Skip while restricted from
+    // seeing this avatar's name so the color can't defeat @shownames. The name
+    // dimming applied to chat names is applied here too so tags match.
+    if (id.notNull() && id != gAgentID
+        && RlvActions::canShowName(RlvActions::SNC_DEFAULT, id))
+    {
+        color = dimNameColor(deterministicAgentColor(id));
+        return true;
+    }
+
+    return false;
+}
+
+LLColor4 ALAvatarGroups::deterministicAgentColor(const LLUUID& id)
+{
+    static LLCachedControl<F32> saturation(gSavedSettings, "AlchemyChatIRCAgentSaturation", 0.7f);
+    static LLCachedControl<F32> lightness(gSavedSettings, "AlchemyChatIRCAgentLightness", 0.9f);
+
+    LLColor4 color;
+    color.setHSL(static_cast<F32>(id.getCRC32() % 360) / 360.f, saturation(), lightness());
+    color.mV[VALPHA] = 1.f;
+
+    return color;
+}
+
+LLColor4 ALAvatarGroups::dimNameColor(const LLColor4& color)
+{
+    static LLCachedControl<F32> scale(gSavedSettings, "AlchemyChatIRCNameLightnessScale", 0.8f);
+
+    F32 hue = 0.f;
+    F32 saturation = 0.f;
+    F32 lightness = 0.f;
+    color.calcHSL(&hue, &saturation, &lightness);
+
+    LLColor4 result;
+    result.setHSL(hue, saturation, lightness * scale());
+    result.mV[VALPHA] = 1.f;
+
+    return result;
 }

--- a/indra/newview/alavatargroups.h
+++ b/indra/newview/alavatargroups.h
@@ -62,10 +62,10 @@ public:
     // Other message categories (self, system, objects, owner-say) keep their
     // user-configured chat colors.
     bool getIRCChatColor(const LLChat& chat, LLUIColor& color);
-    bool getIRCNameColor(const LLChat& chat, const LLUIColor& chat_color, LLUIColor& color);
+    bool getIRCNameColor(const LLChat& chat, LLUIColor& color);
     bool getIRCNameTagColor(const LLUUID& id, LLColor4& color);
 
 private:
     LLColor4 deterministicAgentColor(const LLUUID& id);
-    LLColor4 dimNameColor(const LLColor4& color);
+    LLColor4 nameColor(const LLUUID& id);
 };

--- a/indra/newview/alavatargroups.h
+++ b/indra/newview/alavatargroups.h
@@ -24,7 +24,9 @@
 #include <boost/unordered_map.hpp>
 #include <boost/unordered_set.hpp>
 
+class LLChat;
 class LLColor4;
+class LLUIColor;
 class LLUUID;
 
 class ALAvatarGroups final : public LLSingleton < ALAvatarGroups >
@@ -54,4 +56,16 @@ public:
 
     LLColor4 getAvatarColor(const LLUUID& id, LLColor4 default_color, EColorType color_type);
     std::string getAvatarColorName(const LLUUID& id, std::string_view color_name, EColorType color_type);
+
+    // IRC-style chat coloring: when enabled, gives every other speaker a stable
+    // deterministic color and dims the displayed name relative to its text color.
+    // Other message categories (self, system, objects, owner-say) keep their
+    // user-configured chat colors.
+    bool getIRCChatColor(const LLChat& chat, LLUIColor& color);
+    bool getIRCNameColor(const LLChat& chat, const LLUIColor& chat_color, LLUIColor& color);
+    bool getIRCNameTagColor(const LLUUID& id, LLColor4& color);
+
+private:
+    LLColor4 deterministicAgentColor(const LLUUID& id);
+    LLColor4 dimNameColor(const LLColor4& color);
 };

--- a/indra/newview/app_settings/settings_alchemy.xml
+++ b/indra/newview/app_settings/settings_alchemy.xml
@@ -662,16 +662,16 @@
             <key>Value</key>
             <real>0.9</real>
         </map>
-        <key>AlchemyChatIRCNameLightnessScale</key>
+        <key>AlchemyChatIRCNameLightness</key>
         <map>
             <key>Comment</key>
-            <string>Scales the lightness of the displayed name relative to its IRC-style chat color (0-1).</string>
+            <string>Lightness of the displayed name in IRC-style chat colors; shares the chat color's hue and saturation (0-1).</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
             <string>F32</string>
             <key>Value</key>
-            <real>0.8</real>
+            <real>0.7</real>
         </map>
         <key>AlchemyChatMarkUnnamedObjects</key>
         <map>

--- a/indra/newview/app_settings/settings_alchemy.xml
+++ b/indra/newview/app_settings/settings_alchemy.xml
@@ -618,6 +618,61 @@
             <key>Value</key>
             <string>/tp2cam</string>
         </map>
+        <key>AlchemyChatIRCColorsEnabled</key>
+        <map>
+            <key>Comment</key>
+            <string>Use IRC-style deterministic colors for local chat names and text.</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>Boolean</string>
+            <key>Value</key>
+            <integer>0</integer>
+        </map>
+        <key>AlchemyChatIRCColorNameTags</key>
+        <map>
+            <key>Comment</key>
+            <string>Overwrite each other agent's name tag with their IRC-style per-agent chat color.</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>Boolean</string>
+            <key>Value</key>
+            <integer>0</integer>
+        </map>
+        <key>AlchemyChatIRCAgentSaturation</key>
+        <map>
+            <key>Comment</key>
+            <string>Saturation of the per-agent IRC-style chat colors (0-1).</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>F32</string>
+            <key>Value</key>
+            <real>0.7</real>
+        </map>
+        <key>AlchemyChatIRCAgentLightness</key>
+        <map>
+            <key>Comment</key>
+            <string>Lightness of the per-agent IRC-style chat colors (0-1).</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>F32</string>
+            <key>Value</key>
+            <real>0.9</real>
+        </map>
+        <key>AlchemyChatIRCNameLightnessScale</key>
+        <map>
+            <key>Comment</key>
+            <string>Scales the lightness of the displayed name relative to its IRC-style chat color (0-1).</string>
+            <key>Persist</key>
+            <integer>1</integer>
+            <key>Type</key>
+            <string>F32</string>
+            <key>Value</key>
+            <real>0.8</real>
+        </map>
         <key>AlchemyChatMarkUnnamedObjects</key>
         <map>
             <key>Comment</key>

--- a/indra/newview/llchathistory.cpp
+++ b/indra/newview/llchathistory.cpp
@@ -1380,7 +1380,11 @@ void LLChatHistory::appendMessage(const LLChat& chat, const LLSD &args, const LL
     LLUIColor txt_color = LLUIColorTable::instance().getColor("White");
     LLUIColor name_color = LLUIColorTable::instance().getColor("ChatHeaderDisplayNameColor"); // <alchemy/>
     LLViewerChat::getChatColor(chat, txt_color, alpha);
-    const bool irc_name_color = ALAvatarGroups::instance().getIRCNameColor(chat, name_color);
+    const bool irc_name_color = chat.mSourceType == CHAT_SOURCE_AGENT
+        && chat.mFromID.notNull()
+        && chat.mFromID != gAgentID
+        && chat.mFromName != SYSTEM_FROM
+        && ALAvatarGroups::instance().getIRCNameColor(chat, name_color);
 
     LLFontGL* fontp = LLViewerChat::getChatFont();
     std::string font_name = LLFontGL::nameFromFont(fontp);

--- a/indra/newview/llchathistory.cpp
+++ b/indra/newview/llchathistory.cpp
@@ -69,6 +69,7 @@
 #include "llviewercontrol.h"
 #include "llviewermenu.h"
 #include "llviewerobjectlist.h"
+#include "alavatargroups.h"
 // [SL:KB] - Patch: Chat-Alerts | Checked: 2012-07-10 (Catznip-3.3)
 #include "llaudioengine.h"
 #include "lltextparser.h"
@@ -1379,6 +1380,7 @@ void LLChatHistory::appendMessage(const LLChat& chat, const LLSD &args, const LL
     LLUIColor txt_color = LLUIColorTable::instance().getColor("White");
     LLUIColor name_color = LLUIColorTable::instance().getColor("ChatHeaderDisplayNameColor"); // <alchemy/>
     LLViewerChat::getChatColor(chat, txt_color, alpha);
+    const bool irc_name_color = ALAvatarGroups::instance().getIRCNameColor(chat, txt_color, name_color);
 
     LLFontGL* fontp = LLViewerChat::getChatFont();
     std::string font_name = LLFontGL::nameFromFont(fontp);
@@ -1504,6 +1506,11 @@ void LLChatHistory::appendMessage(const LLChat& chat, const LLSD &args, const LL
                 static LLUIColor link_color = LLUIColorTable::instance().getColor("HTMLLinkColor");
                 link_params.color = link_color;
                 link_params.readonly_color = link_color;
+                if (irc_name_color)
+                {
+                    link_params.color = name_color;
+                    link_params.readonly_color = name_color;
+                }
                 link_params.is_link = true;
                 link_params.link_href = url;
 
@@ -1541,6 +1548,14 @@ void LLChatHistory::appendMessage(const LLChat& chat, const LLSD &args, const LL
             {
                 LLStyle::Params link_params(body_message_params);
                 link_params.overwriteFrom(LLStyleMap::instance().lookupAgent(chat.mFromID));
+                if (irc_name_color)
+                {
+                    // Keep our dimmed name color instead of letting the agent
+                    // SLURL re-parse to the default HTMLLinkColor link style.
+                    link_params.use_default_link_style = false;
+                    link_params.color = name_color;
+                    link_params.readonly_color = name_color;
+                }
 
                 if (use_irssi_text_chat_history)
                 {

--- a/indra/newview/llchathistory.cpp
+++ b/indra/newview/llchathistory.cpp
@@ -1380,7 +1380,7 @@ void LLChatHistory::appendMessage(const LLChat& chat, const LLSD &args, const LL
     LLUIColor txt_color = LLUIColorTable::instance().getColor("White");
     LLUIColor name_color = LLUIColorTable::instance().getColor("ChatHeaderDisplayNameColor"); // <alchemy/>
     LLViewerChat::getChatColor(chat, txt_color, alpha);
-    const bool irc_name_color = ALAvatarGroups::instance().getIRCNameColor(chat, txt_color, name_color);
+    const bool irc_name_color = ALAvatarGroups::instance().getIRCNameColor(chat, name_color);
 
     LLFontGL* fontp = LLViewerChat::getChatFont();
     std::string font_name = LLFontGL::nameFromFont(fontp);

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -3090,12 +3090,14 @@ void LLPanelPreferenceColors::draw()
     static const char* const color_names[] = {
         "UserChatColor", "AgentChatColor", "FriendChatColor", "SystemChatColor",
         "ObjectChatColor", "llOwnerSayChatColor", "LindenChatColor", "HTMLLinkColor",
+        "ChatHeaderTimestampColor",
     };
     std::string signature;
     for (const char* name : color_names)
     {
         const LLColor4& c = LLUIColorTable::instance().getColor(name).get();
-        signature += llformat("%.3f,%.3f,%.3f;", c.mV[VRED], c.mV[VGREEN], c.mV[VBLUE]);
+        signature += llformat("%.3f,%.3f,%.3f,%.3f;",
+            c.mV[VRED], c.mV[VGREEN], c.mV[VBLUE], c.mV[VALPHA]);
     }
     signature += llformat("%d;%.3f;%.3f;%.3f;%d",
         gSavedSettings.getBOOL("AlchemyChatIRCColorsEnabled") ? 1 : 0,
@@ -3145,7 +3147,7 @@ void LLPanelPreferenceColors::updatePreview()
         { K_OWNER,    "llOwnerSayChatColor", "e5e5e5e5-0000-0000-0000-000000000005", 13, 49, "Animation HUD",           "Memory Free: 2167 KiB :)" },
     };
 
-    static const LLUIColor time_color = LLUIColorTable::instance().getColor("ChatHeaderTimestampColor");
+    const LLUIColor time_color = LLUIColorTable::instance().getColor("ChatHeaderTimestampColor");
     const bool use_24h = gSavedSettings.getBOOL("Use24HourClock");
 
     mPreviewEditor->clear();   // clear before re-appending

--- a/indra/newview/llfloaterpreference.cpp
+++ b/indra/newview/llfloaterpreference.cpp
@@ -34,7 +34,12 @@
 
 #include "llfloaterpreference.h"
 
+#include "alavatargroups.h"
 #include "llaudioengine.h"
+#include "llchat.h"
+#include "llstyle.h"
+#include "lluicolortable.h"
+#include "llviewerchat.h"
 #include "message.h"
 #include "llfloaterautoreplacesettings.h"
 #include "llagent.h"
@@ -74,6 +79,8 @@
 #include "llscrolllistitem.h"
 #include "llsliderctrl.h"
 #include "lltabcontainer.h"
+#include "lltextbox.h"
+#include "lltexteditor.h"
 #include "lltrans.h"
 #include "lluri.h"
 #include "llviewercontrol.h"
@@ -3066,6 +3073,162 @@ private:
 static LLPanelInjector<LLPanelPreferenceGraphics> t_pref_graph("panel_preference_graphics");
 static LLPanelInjector<LLPanelPreferencePrivacy> t_pref_privacy("panel_preference_privacy");
 static LLPanelInjector<LLPanelPreferenceSound> t_pref_sound("panel_preference_sound");
+static LLPanelInjector<LLPanelPreferenceColors> t_pref_colors("panel_preference_colors");
+
+bool LLPanelPreferenceColors::postBuild()
+{
+    mPreviewEditor = getChild<LLTextEditor>("irc_chat_preview");
+    updatePreview();
+    return LLPanelPreference::postBuild();
+}
+
+void LLPanelPreferenceColors::draw()
+{
+    // The chat-color swatches commit straight into LLUIColorTable (no settings
+    // signal to listen to), so poll a cheap signature of everything the preview
+    // depends on and re-render only when it actually changes.
+    static const char* const color_names[] = {
+        "UserChatColor", "AgentChatColor", "FriendChatColor", "SystemChatColor",
+        "ObjectChatColor", "llOwnerSayChatColor", "LindenChatColor", "HTMLLinkColor",
+    };
+    std::string signature;
+    for (const char* name : color_names)
+    {
+        const LLColor4& c = LLUIColorTable::instance().getColor(name).get();
+        signature += llformat("%.3f,%.3f,%.3f;", c.mV[VRED], c.mV[VGREEN], c.mV[VBLUE]);
+    }
+    signature += llformat("%d;%.3f;%.3f;%.3f;%d",
+        gSavedSettings.getBOOL("AlchemyChatIRCColorsEnabled") ? 1 : 0,
+        gSavedSettings.getF32("AlchemyChatIRCAgentSaturation"),
+        gSavedSettings.getF32("AlchemyChatIRCAgentLightness"),
+        gSavedSettings.getF32("AlchemyChatIRCNameLightness"),
+        gSavedSettings.getBOOL("Use24HourClock") ? 1 : 0);
+
+    if (signature != mPreviewSignature)
+    {
+        mPreviewSignature = signature;
+        updatePreview();
+    }
+
+    LLPanelPreference::draw();
+}
+
+void LLPanelPreferenceColors::updatePreview()
+{
+    if (!mPreviewEditor)
+        return;
+
+    // One line per chat category the panel above exposes. Each carries the base
+    // color the real getChatColor() switch would pick (friend/Linden can't be
+    // detected from a fake id, so we set it explicitly), plus a stable id so the
+    // per-avatar IRC color stays constant between refreshes. The IRC override and
+    // name dimming are then applied through the real ALAvatarGroups calls, so the
+    // preview tracks the live colors and settings exactly like in-world local chat.
+    enum EKind { K_SYSTEM, K_SELF, K_RESIDENT, K_FRIEND, K_LINDEN, K_OBJECT, K_OWNER };
+    static const struct
+    {
+        EKind       kind;
+        const char* color;  // base text color name
+        const char* id;     // stable per-avatar id (empty for system/self)
+        S32         hour;    // mock 24h timestamp, formatted per Use24HourClock
+        S32         minute;
+        const char* name;   // speaker name ("" hides the name prefix)
+        const char* text;
+    } samples[] = {
+        { K_SYSTEM,   "SystemChatColor",     "",                                     13, 42, "",                        "Welcome to Quirk Island. Mind the dancing llamas." },
+        { K_SELF,     "UserChatColor",       "",                                     13, 43, "You",                     "ok who moved my virtual cheese" },
+        { K_RESIDENT, "AgentChatColor",      "a1a1a1a1-0000-0000-0000-000000000001", 13, 44, "Bartholomew Bumblecrash", "anyone else seeing the sky do the wobble thing?" },
+        { K_RESIDENT, "AgentChatColor",      "f6f6f6f6-0000-0000-0000-000000000006", 13, 45, "Wandering Pixel",         "https://marketplace.secondlife.com/" },
+        { K_FRIEND,   "FriendChatColor",     "b2b2b2b2-0000-0000-0000-000000000002", 13, 46, "Glittertoes McSparkle",   "omg hi!! brb taming a baby dragon" },
+        { K_LINDEN,   "LindenChatColor",     "c3c3c3c3-0000-0000-0000-000000000003", 13, 47, "Governor Linden",         "Rolling restart in 5, hold onto your hats." },
+        { K_OBJECT,   "ObjectChatColor",     "d4d4d4d4-0000-0000-0000-000000000004", 13, 48, "Object",                  "Welcome to Help Island!" },
+        { K_OWNER,    "llOwnerSayChatColor", "e5e5e5e5-0000-0000-0000-000000000005", 13, 49, "Animation HUD",           "Memory Free: 2167 KiB :)" },
+    };
+
+    static const LLUIColor time_color = LLUIColorTable::instance().getColor("ChatHeaderTimestampColor");
+    const bool use_24h = gSavedSettings.getBOOL("Use24HourClock");
+
+    mPreviewEditor->clear();   // clear before re-appending
+
+    bool prepend_newline = false;  // newline before every line except the first
+    for (const auto& s : samples)
+    {
+        LLChat chat;
+        chat.mFromName = s.name;
+        chat.mText     = s.text;
+        switch (s.kind)
+        {
+        case K_SYSTEM:
+            chat.mSourceType = CHAT_SOURCE_SYSTEM;
+            break;
+        case K_SELF:
+            chat.mSourceType = CHAT_SOURCE_AGENT;
+            chat.mFromID     = gAgentID;
+            break;
+        case K_OBJECT:
+            chat.mSourceType = CHAT_SOURCE_OBJECT;
+            chat.mFromID     = LLUUID(s.id);
+            break;
+        case K_OWNER:
+            chat.mSourceType = CHAT_SOURCE_OBJECT;
+            chat.mChatType   = CHAT_TYPE_OWNER;
+            chat.mFromID     = LLUUID(s.id);
+            break;
+        default:  // resident / friend / Linden are all "other agents"
+            chat.mSourceType = CHAT_SOURCE_AGENT;
+            chat.mFromID     = LLUUID(s.id);
+            break;
+        }
+
+        // Base category color, then the live IRC overrides (mirrors getChatColor +
+        // getIRCNameColor in llchathistory.cpp). getIRCChatColor only recolors other
+        // agents, so self/system/object/owner keep their configured color. Names are
+        // clickable SLURLs in chat, so by default they take the link color; when IRC
+        // coloring is on, getIRCNameColor overrides that with the per-agent name color.
+        LLUIColor txt_color = LLUIColorTable::instance().getColor(s.color);
+        ALAvatarGroups::instance().getIRCChatColor(chat, txt_color);
+
+        LLUIColor name_color = LLUIColorTable::instance().getColor("HTMLLinkColor");
+        ALAvatarGroups::instance().getIRCNameColor(chat, name_color);
+
+        // Timestamp prefix, like nearby chat: "[hh:mm] ", honoring the
+        // Use24HourClock pref the way LLFloaterIMSessionTab::appendTime() does.
+        std::string time_str;
+        if (use_24h)
+        {
+            time_str = llformat("%d:%02d", s.hour, s.minute);
+        }
+        else
+        {
+            S32 h12 = s.hour % 12;
+            if (h12 == 0) h12 = 12;
+            time_str = llformat("%d:%02d %s", h12, s.minute, s.hour < 12 ? "AM" : "PM");
+        }
+
+        LLStyle::Params time_style;
+        time_style.color(time_color);
+        time_style.readonly_color(time_color);
+        mPreviewEditor->appendText("[" + time_str + "] ", prepend_newline, time_style);
+        prepend_newline = false;  // keep the rest of the line attached to the timestamp
+
+        if (!chat.mFromName.empty())
+        {
+            LLStyle::Params name_style;
+            name_style.color(name_color);
+            name_style.readonly_color(name_color);
+            mPreviewEditor->appendText(chat.mFromName + ": ", prepend_newline, name_style);
+        }
+
+        // parse_urls is set on the widget, so any URL in the text is linkified
+        // (and colored HTMLLinkColor) automatically by appendText.
+        LLStyle::Params text_style;
+        text_style.color(txt_color);
+        text_style.readonly_color(txt_color);
+        mPreviewEditor->appendText(chat.mText, prepend_newline, text_style);
+
+        prepend_newline = true;
+    }
+}
 
 bool LLPanelPreferenceSound::postBuild()
 {

--- a/indra/newview/llfloaterpreference.h
+++ b/indra/newview/llfloaterpreference.h
@@ -53,6 +53,7 @@ class LLScrollListCell;
 class LLSliderCtrl;
 class LLSD;
 class LLTextBox;
+class LLTextEditor;
 struct skin_t;
 
 namespace ll
@@ -386,6 +387,27 @@ private:
     // destroyed; boost::signals2 makes that safe even if the engine
     // outlives the panel.
     boost::signals2::scoped_connection mDevicesChangedConn;
+};
+
+// Colors > Chat preferences panel. Renders a live mock-chat preview that
+// re-colors whenever a chat-color swatch or any AlchemyChatIRC* setting
+// changes, using the real chat-color path so it matches in-world local chat.
+class LLPanelPreferenceColors : public LLPanelPreference
+{
+    LOG_CLASS(LLPanelPreferenceColors);
+public:
+    bool postBuild() override;
+    void draw() override;
+
+private:
+    void updatePreview();
+
+    LLTextEditor* mPreviewEditor = nullptr;
+
+    // Signature of the colors/settings the preview depends on. The chat-color
+    // swatches commit straight into LLUIColorTable (no settings signal), so
+    // draw() polls this and re-renders only when it actually changes.
+    std::string mPreviewSignature;
 };
 
 class LLPanelPreferenceControls : public LLPanelPreference, public LLKeyBindResponderInterface

--- a/indra/newview/llviewerchat.cpp
+++ b/indra/newview/llviewerchat.cpp
@@ -51,6 +51,8 @@ void LLViewerChat::getChatColor(const LLChat& chat, LLUIColor& r_color, F32& r_c
     }
     else
     {
+        if (!ALAvatarGroups::instance().getIRCChatColor(chat, r_color))
+        {
         switch(chat.mSourceType)
         {
             case CHAT_SOURCE_SYSTEM:
@@ -95,6 +97,7 @@ void LLViewerChat::getChatColor(const LLChat& chat, LLUIColor& r_color, F32& r_c
                 break;
             default:
                 r_color = LLUIColorTable::instance().getColor("White");
+        }
         }
 
         if (!chat.mPosAgent.isExactlyZero())

--- a/indra/newview/llvoavatar.cpp
+++ b/indra/newview/llvoavatar.cpp
@@ -4038,7 +4038,10 @@ LLColor4 LLVOAvatar::getNameTagColor(bool is_friend)
 #endif
     static LLUIColor name_tag_match = LLUIColorTable::instance().getColor("NameTagMatch");
     LLColor4 color_name = name_tag_match;
-    color_name = ALAvatarGroups::instance().getAvatarColor(getID(), color_name, ALAvatarGroups::COLOR_NAMETAG);
+    if (!ALAvatarGroups::instance().getIRCNameTagColor(getID(), color_name))
+    {
+        color_name = ALAvatarGroups::instance().getAvatarColor(getID(), color_name, ALAvatarGroups::COLOR_NAMETAG);
+    }
 
     return color_name;
 }

--- a/indra/newview/skins/default/xui/en/floater_preferences.xml
+++ b/indra/newview/skins/default/xui/en/floater_preferences.xml
@@ -144,7 +144,7 @@
          help_topic="preferences_msgs_tab"
          name="msgs" />
         <panel
-		 class="panel_preference"
+		 class="panel_preference_colors"
          filename="panel_preferences_colors.xml"
          label="Colors"
          layout="topleft"

--- a/indra/newview/skins/default/xui/en/panel_preferences_colors.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_colors.xml
@@ -814,6 +814,89 @@
     width="95">
      Lindens
    </text>
+   <text
+    type="string"
+    length="1"
+    follows="left|top"
+    height="12"
+    layout="topleft"
+    left="30"
+    name="irc_colors_label"
+    top_pad="20"
+    width="300">
+     IRC-style chat colors:
+   </text>
+   <check_box
+    control_name="AlchemyChatIRCColorsEnabled"
+    follows="left|top"
+    height="16"
+    label="Give each other speaker a unique color"
+    layout="topleft"
+    left="40"
+    name="irc_chat_colors_enabled"
+    tool_tip="Colors other people's local chat by a stable per-avatar color. Your own, system, object and owner-say messages keep the colors set above."
+    top_pad="12"
+    width="440"/>
+   <check_box
+    control_name="AlchemyChatIRCColorNameTags"
+    enabled_control="AlchemyChatIRCColorsEnabled"
+    follows="left|top"
+    height="16"
+    label="Also color their name tag to match"
+    layout="topleft"
+    left="40"
+    name="irc_chat_colors_name_tags"
+    tool_tip="Overwrites each other person's floating name tag with the same per-avatar color used for their chat."
+    top_pad="4"
+    width="440"/>
+   <slider
+    control_name="AlchemyChatIRCAgentSaturation"
+    decimal_digits="2"
+    follows="left|top"
+    height="16"
+    increment="0.01"
+    initial_value="0.7"
+    label="Saturation"
+    label_width="120"
+    layout="topleft"
+    left="40"
+    max_val="1"
+    min_val="0"
+    name="irc_agent_saturation"
+    top_pad="8"
+    width="300"/>
+   <slider
+    control_name="AlchemyChatIRCAgentLightness"
+    decimal_digits="2"
+    follows="left|top"
+    height="16"
+    increment="0.01"
+    initial_value="0.9"
+    label="Lightness"
+    label_width="120"
+    layout="topleft"
+    left="40"
+    max_val="1"
+    min_val="0"
+    name="irc_agent_lightness"
+    top_pad="4"
+    width="300"/>
+   <slider
+    control_name="AlchemyChatIRCNameLightnessScale"
+    decimal_digits="2"
+    follows="left|top"
+    height="16"
+    increment="0.01"
+    initial_value="0.8"
+    label="Name dimming"
+    label_width="120"
+    layout="topleft"
+    left="40"
+    max_val="1"
+    min_val="0"
+    name="irc_name_lightness_scale"
+    top_pad="4"
+    width="300"/>
    </panel>
  </tab_container>
 </panel>

--- a/indra/newview/skins/default/xui/en/panel_preferences_colors.xml
+++ b/indra/newview/skins/default/xui/en/panel_preferences_colors.xml
@@ -2,23 +2,23 @@
 <panel
  border="true"
  follows="left|top|right|bottom"
- height="408"
+ height="440"
  label="Colors"
  layout="topleft"
  left="102"
  name="colors_panel"
  top="1"
  width="517">
- <tab_container 
- top_pad="0" 
- enabled="true" 
- follows="left|top" 
- height="430" 
+ <tab_container
+ top_pad="0"
+ enabled="true"
+ follows="left|top"
+ height="440"
  left_delta="0"
- mouse_opaque="false" 
- name="color_tab_container" 
+ mouse_opaque="false"
+ name="color_tab_container"
  tab_position="top"
- tab_stop="false" 
+ tab_stop="false"
  width="517">
  <panel
  label="General"
@@ -606,7 +606,7 @@
     layout="topleft"
     left="40"
     name="system"
-    top_pad="22"
+    top_pad="16"
     width="44" >
      <color_swatch.init_callback
       function="Pref.getUIColor"
@@ -699,7 +699,7 @@
     layout="topleft"
     left="40"
     name="owner"
-    top_pad="22"
+    top_pad="16"
     width="44" >
      <color_swatch.init_callback
       function="Pref.getUIColor"
@@ -792,7 +792,7 @@
     layout="topleft"
     left="40"
     name="linden"
-    top_pad="22"
+    top_pad="16"
     width="44" >
      <color_swatch.init_callback
       function="Pref.getUIColor"
@@ -882,21 +882,51 @@
     top_pad="4"
     width="300"/>
    <slider
-    control_name="AlchemyChatIRCNameLightnessScale"
+    control_name="AlchemyChatIRCNameLightness"
     decimal_digits="2"
     follows="left|top"
     height="16"
     increment="0.01"
-    initial_value="0.8"
-    label="Name dimming"
+    initial_value="0.7"
+    label="Name lightness"
     label_width="120"
     layout="topleft"
     left="40"
     max_val="1"
     min_val="0"
-    name="irc_name_lightness_scale"
+    name="irc_name_lightness"
     top_pad="4"
     width="300"/>
+   <text
+    type="string"
+    length="1"
+    follows="left|top"
+    height="12"
+    layout="topleft"
+    left="30"
+    name="irc_preview_label"
+    top_pad="8"
+    width="300">
+     Compact Chat Preview:
+   </text>
+   <text_editor
+    follows="left|top"
+    font="SansSerifSmall"
+    height="88"
+    layout="topleft"
+    left="30"
+    name="irc_chat_preview"
+    read_only="true"
+    border_visible="true"
+    bg_visible="true"
+    bg_readonly_color="DkGray2"
+    max_length="65536"
+    parse_urls="true"
+    word_wrap="true"
+    track_bottom="false"
+    top_pad="10"
+    width="437"
+    tool_tip="Live preview of how local chat will look with the colors and settings above."/>
    </panel>
  </tab_container>
 </panel>


### PR DESCRIPTION
Optionally give every other local-chat speaker a stable, deterministic color (HSL from a hash of their UUID) and their displayed name relative to its text color, IRC-style.

Also ties into `RlvActions::canShowName` to try avoid defeating `@shownames`.

https://github.com/user-attachments/assets/006a6153-2d24-4591-921d-ed550bef2a70
