### PR TITLE
Fix use-after-free in llMeshRepository and llView

### DIFF
--- a/indra/llui/llview.cpp
+++ b/indra/llui/llview.cpp
@@ -603,9 +603,18 @@ void LLView::deleteAllChildren()
     while (!mChildList.empty())
     {
         LLView* viewp = mChildList.front();
+        // Pop before deleting. The child's destructor (and its children's
+        // destructors, e.g. LLFloater::~LLFloater deleting mDragHandle and
+        // mResizeBar/mResizeHandle explicitly) call ~LLView(), which calls
+        // mParentView->removeChild(this). If viewp is still at the front of
+        // the list at that point, removeChild() erases it -- but pop_front()
+        // below then removes whatever is now at the front instead, leaving the
+        // originally-next entry as a dangling pointer in mChildList.
+        // Popping first means removeChild() finds mParentView == NULL and
+        // takes the no-op warning branch, keeping the list consistent.
+        mChildList.pop_front();
         viewp->mParentView = NULL;
         delete viewp;
-        mChildList.pop_front();
     }
     updateBoundingRect();
 }

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -4558,6 +4558,21 @@ void LLMeshRepository::unregisterMesh(LLVOVolume* vobj, const LLVolumeParams& me
         llassert(!param_iter->second.mVolumes.contains(vobj));
         if (param_iter->second.mVolumes.empty())
         {
+            // Remove the associated pending request from the submission queue
+            // so it is not dispatched after all tracking data is gone.
+            // getRequest() locks the weak_ptr stored in MeshLoadData; a non-null
+            // result means the request is still queued in mPendingRequests (if it
+            // had already been submitted and released, lock() returns null and
+            // we correctly skip the scan).
+            const std::shared_ptr<PendingRequestBase> req = param_iter->second.getRequest();
+            if (req)
+            {
+                auto it = std::find(mPendingRequests.begin(), mPendingRequests.end(), req);
+                if (it != mPendingRequests.end())
+                {
+                    mPendingRequests.erase(it);
+                }
+            }
             lod.erase(param_iter);
         }
     }
@@ -4576,6 +4591,19 @@ void LLMeshRepository::unregisterSkinInfo(const LLUUID& mesh_id, LLVOVolume* vob
         llassert(!skin_pair_iter->second.mVolumes.contains(vobj));
         if (skin_pair_iter->second.mVolumes.empty())
         {
+            // Same as unregisterMesh: pull the pending request out of the queue
+            // before dropping the tracking entry so we don't submit a request
+            // that has no listener left. getRequest() locks the weak_ptr; null
+            // means it was already submitted and released, so no scan is needed.
+            const std::shared_ptr<PendingRequestBase> req = skin_pair_iter->second.getRequest();
+            if (req)
+            {
+                auto it = std::find(mPendingRequests.begin(), mPendingRequests.end(), req);
+                if (it != mPendingRequests.end())
+                {
+                    mPendingRequests.erase(it);
+                }
+            }
             mLoadingSkins.erase(skin_pair_iter);
         }
     }
@@ -4602,6 +4630,11 @@ void LLMeshRepository::unregisterAllMeshes()
         lod.clear();
     }
     mLoadingSkins.clear();
+    // mPendingRequests holds shared_ptrs to the same PendingRequestBase objects
+    // that were tracked by the maps above. Now that every tracking entry is gone
+    // any queued request has no volumes to notify, so discard them here to keep
+    // ownership consistent and avoid submitting requests against freed data.
+    mPendingRequests.clear();
 }
 
 S32 LLMeshRepository::loadMesh(LLVOVolume* vobj, const LLVolumeParams& mesh_params, S32 new_lod, S32 last_lod)
@@ -5024,8 +5057,13 @@ void LLMeshRepository::notifyLoadedMeshes()
     // submission run. Any submission entry point added here must take mMutex itself.
     for (const std::shared_ptr<PendingRequestBase>& req_p : submit_batch)
     {
-        // todo: check hasTrackedData here and erase request if none
-        // since this is supposed to mean that request was removed
+        // If all tracked volumes were unregistered while this request was still
+        // queued, mTrackedData will be null and there is nothing left to notify.
+        // Skip rather than dereferencing a potentially stale object.
+        if (!req_p || !req_p->hasTrackedData())
+        {
+            continue;
+        }
         switch (req_p->getRequestType())
         {
         case MESH_REQUEST_LOD:

--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -4570,6 +4570,10 @@ void LLMeshRepository::unregisterMesh(LLVOVolume* vobj, const LLVolumeParams& me
                 auto it = std::find(mPendingRequests.begin(), mPendingRequests.end(), req);
                 if (it != mPendingRequests.end())
                 {
+                    if (req->getRequestType() == MESH_REQUEST_LOD)
+                    {
+                        LLMeshRepository::sLODPending--;
+                    }
                     mPendingRequests.erase(it);
                 }
             }
@@ -4634,6 +4638,15 @@ void LLMeshRepository::unregisterAllMeshes()
     // that were tracked by the maps above. Now that every tracking entry is gone
     // any queued request has no volumes to notify, so discard them here to keep
     // ownership consistent and avoid submitting requests against freed data.
+    // Decrement sLODPending for any LOD requests being discarded to keep the
+    // counter balanced with the increments in loadMesh().
+    for (const std::shared_ptr<PendingRequestBase>& req : mPendingRequests)
+    {
+        if (req && req->getRequestType() == MESH_REQUEST_LOD)
+        {
+            LLMeshRepository::sLODPending--;
+        }
+    }
     mPendingRequests.clear();
 }
 
@@ -5062,6 +5075,11 @@ void LLMeshRepository::notifyLoadedMeshes()
         // Skip rather than dereferencing a potentially stale object.
         if (!req_p || !req_p->hasTrackedData())
         {
+            // Keep sLODPending balanced with the increment in loadMesh().
+            if (req_p && req_p->getRequestType() == MESH_REQUEST_LOD)
+            {
+                LLMeshRepository::sLODPending--;
+            }
             continue;
         }
         switch (req_p->getRequestType())

--- a/indra/newview/llmeshrepository.h
+++ b/indra/newview/llmeshrepository.h
@@ -336,6 +336,12 @@ public:
             request->setScoreDirty();
         }
     }
+
+    // Returns the associated pending request if it is still alive (i.e. still
+    // sitting in mPendingRequests and not yet submitted). Returns null once
+    // the request has been submitted and released from that vector.
+    std::shared_ptr<PendingRequestBase> getRequest() const { return mRequest.lock(); }
+
     boost::unordered_set<LLVOVolume*> mVolumes;
 private:
     std::weak_ptr<PendingRequestBase> mRequest;


### PR DESCRIPTION
## Description

llmeshrepository: PendingRequestBase objects in mPendingRequests could be submitted after all tracking volumes were unregistered, dereferencing freed data. Fix by guarding the submit loop with hasTrackedData(), eagerly erasing from mPendingRequests in unregisterMesh/unregisterSkinInfo when the last volume is removed, and clearing mPendingRequests in unregisterAllMeshes to keep ownership consistent with the loading maps. Adds MeshLoadData::getRequest() to expose the weak_ptr for the erase scan.

llview: deleteAllChildren() called delete before pop_front(), allowing the child destructor chain (e.g. LLFloater explicitly deleting mDragHandle and resize handles) to call removeChild() and mutate mChildList mid-loop, leaving the next entry as a dangling pointer. Fix by popping before deleting so removeChild() finds mParentView == NULL and no-ops.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
