### PR TITLE
Unify chat gesture and command completion

### DIFF
--- a/indra/llui/CMakeLists.txt
+++ b/indra/llui/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(llui
     llbadgeholder.cpp
     llbadgeowner.cpp
     llbutton.cpp
+    llchatautocompletemodel.cpp
     llchatentry.cpp
     llchatmentionhelper.cpp
     llcheckboxctrl.cpp
@@ -121,6 +122,7 @@ target_sources(llui
     llbadgeowner.h
     llbutton.h
     llcallbackmap.h
+    llchatautocompletemodel.h
     llchatentry.h
     llchat.h
     llchatmentionhelper.h
@@ -297,6 +299,7 @@ if(BUILD_TESTING)
   set(test_libs llmessage llcorehttp llxml llrender llcommon ${spellcheck_lib})
 
   SET(llui_TEST_SOURCE_FILES
+      llchatautocompletemodel.cpp
       llurlmatch.cpp
       )
   set_property( SOURCE ${llui_TEST_SOURCE_FILES} PROPERTY LL_TEST_ADDITIONAL_LIBRARIES ${test_libs})

--- a/indra/llui/llchatautocompletemodel.cpp
+++ b/indra/llui/llchatautocompletemodel.cpp
@@ -1,0 +1,45 @@
+/**
+ * @file llchatautocompletemodel.cpp
+ * @brief Data and keyboard policy shared by chat autocomplete controls.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Alchemy Viewer Source Code
+ * Copyright (C) 2026, Alchemy Viewer Project.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * $/LicenseInfo$
+ */
+
+#include "llchatautocompletemodel.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace LLChatAutocompleteModel
+{
+CommitAction getCommitAction(
+    bool return_key,
+    const std::string& editor_text,
+    const Candidate& candidate)
+{
+    const bool is_full_match = editor_text.size() == candidate.value.size()
+        && std::equal(
+            editor_text.begin(),
+            editor_text.end(),
+            candidate.value.begin(),
+            [](unsigned char left, unsigned char right)
+            {
+                return std::tolower(left) == std::tolower(right);
+            });
+
+    if (return_key && is_full_match && !candidate.accepts_arguments)
+    {
+        return CommitAction::SUBMIT;
+    }
+
+    return CommitAction::COMPLETE;
+}
+}

--- a/indra/llui/llchatautocompletemodel.h
+++ b/indra/llui/llchatautocompletemodel.h
@@ -1,0 +1,40 @@
+/**
+ * @file llchatautocompletemodel.h
+ * @brief Data and keyboard policy shared by chat autocomplete controls.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Alchemy Viewer Source Code
+ * Copyright (C) 2026, Alchemy Viewer Project.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * $/LicenseInfo$
+ */
+
+#pragma once
+
+#include <string>
+
+namespace LLChatAutocompleteModel
+{
+struct Candidate
+{
+    std::string value;
+    std::string trigger;
+    std::string name;
+    bool accepts_arguments = false;
+};
+
+enum class CommitAction
+{
+    COMPLETE,
+    SUBMIT
+};
+
+CommitAction getCommitAction(
+    bool return_key,
+    const std::string& editor_text,
+    const Candidate& candidate);
+}

--- a/indra/llui/llgestureautocompletehelper.cpp
+++ b/indra/llui/llgestureautocompletehelper.cpp
@@ -32,6 +32,8 @@
 #include "llfocusmgr.h"
 #include "lluictrl.h"
 
+#include <algorithm>
+
 constexpr char GESTURE_AUTOCOMPLETE_FLOATER[] = "gesture_autocomplete_picker";
 
 bool LLGestureAutocompleteHelper::isActive(const LLUICtrl* ctrl) const
@@ -43,20 +45,18 @@ void LLGestureAutocompleteHelper::showHelper(
     LLUICtrl* host_ctrl,
     const std::vector<Row>& rows,
     size_t total,
-    std::function<void(std::string)> commit_cb)
+    std::function<void(const Row&, CommitAction)> commit_cb)
 {
     if (mHelperHandle.isDead())
     {
         LLFloater* helper_floater = LLFloaterReg::getInstance(GESTURE_AUTOCOMPLETE_FLOATER);
         mHelperHandle = helper_floater->getHandle();
-        mHelperCommitConn = helper_floater->setCommitCallback(
-            [this](LLUICtrl*, const LLSD& param) { onCommitGesture(param.asString()); });
     }
 
     setHostCtrl(host_ctrl);
     mRows = rows;
     mTotal = total;
-    mGestureCommitCb = commit_cb;
+    mCommitCb = commit_cb;
 
     S32 floater_x, floater_y;
     LLRect host_rect = host_ctrl->getRect();
@@ -94,11 +94,22 @@ bool LLGestureAutocompleteHelper::handleKey(const LLUICtrl* ctrl, KEY key, MASK 
     return mHelperHandle.get()->handleKey(key, mask, true);
 }
 
-void LLGestureAutocompleteHelper::onCommitGesture(const std::string& trigger)
+void LLGestureAutocompleteHelper::onCommit(const std::string& value, bool return_key)
 {
-    if (!mHostHandle.isDead() && mGestureCommitCb)
+    const auto row_it = std::find_if(
+        mRows.begin(),
+        mRows.end(),
+        [&value](const Row& row) { return row.value == value; });
+
+    if (!mHostHandle.isDead() && row_it != mRows.end() && mCommitCb)
     {
-        mGestureCommitCb(trigger);
+        const Row row = *row_it;
+        const CommitAction action = LLChatAutocompleteModel::getCommitAction(
+            return_key,
+            getHostCtrl()->getValue().asString(),
+            row);
+        auto commit_cb = mCommitCb;
+        commit_cb(row, action);
     }
 
     hideHelper(getHostCtrl());
@@ -131,7 +142,7 @@ void LLGestureAutocompleteHelper::setHostCtrl(LLUICtrl* host_ctrl)
     {
         mHostCtrlFocusLostConn.disconnect();
         mHostHandle.markDead();
-        mGestureCommitCb = {};
+        mCommitCb = {};
         mRows.clear();
         mTotal = 0;
 

--- a/indra/llui/llgestureautocompletehelper.h
+++ b/indra/llui/llgestureautocompletehelper.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "llchatautocompletemodel.h"
 #include "llhandle.h"
 #include "llsingleton.h"
 
@@ -42,22 +43,18 @@ class LLGestureAutocompleteHelper : public LLSingleton<LLGestureAutocompleteHelp
     ~LLGestureAutocompleteHelper() override {}
 
 public:
-    struct Row
-    {
-        std::string value;
-        std::string trigger;
-        std::string name;
-    };
+    using Row = LLChatAutocompleteModel::Candidate;
+    using CommitAction = LLChatAutocompleteModel::CommitAction;
 
     bool isActive(const LLUICtrl* ctrl) const;
     void showHelper(
         LLUICtrl* host_ctrl,
         const std::vector<Row>& rows,
         size_t total,
-        std::function<void(std::string)> commit_cb);
+        std::function<void(const Row&, CommitAction)> commit_cb);
     void hideHelper(const LLUICtrl* ctrl = nullptr);
     bool handleKey(const LLUICtrl* ctrl, KEY key, MASK mask);
-    void onCommitGesture(const std::string& trigger);
+    void onCommit(const std::string& value, bool return_key);
 
     const std::vector<Row>& rows() const { return mRows; }
     size_t total() const { return mTotal; }
@@ -72,8 +69,7 @@ private:
     LLHandle<LLUICtrl>  mHostHandle;
     LLHandle<LLFloater> mHelperHandle;
     boost::signals2::connection mHostCtrlFocusLostConn;
-    boost::signals2::connection mHelperCommitConn;
-    std::function<void(std::string)> mGestureCommitCb;
+    std::function<void(const Row&, CommitAction)> mCommitCb;
 
     std::vector<Row> mRows;
     size_t mTotal = 0;

--- a/indra/llui/tests/llchatautocompletemodel_test.cpp
+++ b/indra/llui/tests/llchatautocompletemodel_test.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file llchatautocompletemodel_test.cpp
+ * @brief Unit tests for chat autocomplete keyboard behavior.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Alchemy Viewer Source Code
+ * Copyright (C) 2026, Alchemy Viewer Project.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * $/LicenseInfo$
+ */
+
+#include "linden_common.h"
+
+#include "../test/lltut.h"
+
+#include "../llchatautocompletemodel.h"
+
+namespace tut
+{
+struct chat_autocomplete_model_data
+{
+    using Action = LLChatAutocompleteModel::CommitAction;
+    using Candidate = LLChatAutocompleteModel::Candidate;
+};
+
+typedef test_group<chat_autocomplete_model_data> chat_autocomplete_model_group;
+typedef chat_autocomplete_model_group::object chat_autocomplete_model_object;
+chat_autocomplete_model_group chat_autocomplete_model_tests("LLChatAutocompleteModel");
+
+template<> template<>
+void chat_autocomplete_model_object::test<1>()
+{
+    Candidate gesture{ "/internet", "/internet", "internet yamero full ver.", false };
+
+    ensure(
+        "return submits a fully prefilled gesture",
+        LLChatAutocompleteModel::getCommitAction(true, "/internet", gesture) == Action::SUBMIT);
+    ensure(
+        "gesture comparison ignores typed capitalization",
+        LLChatAutocompleteModel::getCommitAction(true, "/INTERNET", gesture) == Action::SUBMIT);
+    ensure(
+        "return completes a partial gesture",
+        LLChatAutocompleteModel::getCommitAction(true, "/inter", gesture) == Action::COMPLETE);
+}
+
+template<> template<>
+void chat_autocomplete_model_object::test<2>()
+{
+    Candidate command{ "/plat", "/plat", "Rez a platform", true };
+    Candidate immediate_command{ "/home", "/home", "Teleport home", false };
+
+    ensure(
+        "return leaves room for supported command arguments",
+        LLChatAutocompleteModel::getCommitAction(true, "/plat", command) == Action::COMPLETE);
+    ensure(
+        "return submits a complete command without arguments",
+        LLChatAutocompleteModel::getCommitAction(true, "/home", immediate_command) == Action::SUBMIT);
+}
+
+template<> template<>
+void chat_autocomplete_model_object::test<3>()
+{
+    Candidate gesture{ "/internet", "/internet", "internet yamero full ver.", false };
+    Candidate command{ "/home", "/home", "Teleport home", false };
+
+    ensure(
+        "tab always completes a gesture",
+        LLChatAutocompleteModel::getCommitAction(false, "/internet", gesture) == Action::COMPLETE);
+    ensure(
+        "tab always completes a command",
+        LLChatAutocompleteModel::getCommitAction(false, "/home", command) == Action::COMPLETE);
+}
+}

--- a/indra/newview/CMakeLists.txt
+++ b/indra/newview/CMakeLists.txt
@@ -157,6 +157,7 @@ set(viewer_SOURCE_FILES
     alassetblocklist.cpp
     alavataractions.cpp
     alavatargroups.cpp
+    alchatautocomplete.cpp
     alchatbar.cpp
     alchatcommand.cpp
     alcheatcodes.cpp
@@ -938,6 +939,7 @@ set(viewer_HEADER_FILES
     alassetblocklist.h
     alavataractions.h
     alavatargroups.h
+    alchatautocomplete.h
     alchatbar.h
     alchatcommand.h
     alclassifieditem.h

--- a/indra/newview/alchatautocomplete.cpp
+++ b/indra/newview/alchatautocomplete.cpp
@@ -1,0 +1,153 @@
+/**
+ * @file alchatautocomplete.cpp
+ * @brief Gesture and command completion for nearby chat editors.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Alchemy Viewer Source Code
+ * Copyright (C) 2026, Alchemy Viewer Project.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * $/LicenseInfo$
+ */
+
+#include "llviewerprecompiledheaders.h"
+
+#include "alchatautocomplete.h"
+
+#include "alchatcommand.h"
+#include "llchatentry.h"
+#include "llgesturemgr.h"
+#include "llmultigesture.h"
+#include "llviewercontrol.h"
+
+#include <map>
+#include <utility>
+
+namespace
+{
+constexpr size_t MAX_AUTOCOMPLETE_ROWS = 50;
+
+std::string lowercase(std::string value)
+{
+    LLStringUtil::toLower(value);
+    return value;
+}
+
+void addCandidate(
+    std::map<std::string, LLGestureAutocompleteHelper::Row>& candidates,
+    const std::string& prefix,
+    const std::string& trigger,
+    const std::string& name,
+    bool accepts_arguments)
+{
+    if (trigger.empty() || trigger[0] != '/')
+    {
+        return;
+    }
+
+    const std::string lower_trigger = lowercase(trigger);
+    if (lower_trigger.compare(0, prefix.size(), prefix) != 0)
+    {
+        return;
+    }
+
+    candidates.try_emplace(
+        lower_trigger,
+        LLGestureAutocompleteHelper::Row{ trigger, trigger, name, accepts_arguments });
+}
+
+bool buildRows(
+    const std::string& prefix,
+    std::vector<LLGestureAutocompleteHelper::Row>& rows,
+    size_t& total)
+{
+    rows.clear();
+    total = 0;
+
+    if (prefix.size() < 2 || prefix[0] != '/' || prefix.find_first_of(" \t") != std::string::npos)
+    {
+        return false;
+    }
+
+    const std::string lower_prefix = lowercase(prefix);
+    std::map<std::string, LLGestureAutocompleteHelper::Row> candidates;
+
+    if (gSavedSettings.getBOOL("ChatAutocompleteGestures"))
+    {
+        const LLGestureMgr::item_map_t& active = LLGestureMgr::instance().getActiveGestures();
+        for (const auto& entry : active)
+        {
+            LLMultiGesture* gesture = entry.second;
+            if (gesture)
+            {
+                addCandidate(
+                    candidates,
+                    lower_prefix,
+                    gesture->getTrigger(),
+                    gesture->mName,
+                    false);
+            }
+        }
+    }
+
+    for (const ALChatCommand::AutocompleteCommand& command : ALChatCommand::getAutocompleteCommands())
+    {
+        addCandidate(
+            candidates,
+            lower_prefix,
+            command.trigger,
+            command.description,
+            command.accepts_arguments);
+    }
+
+    addCandidate(candidates, lower_prefix, "/me", "Pose: message", true);
+    addCandidate(candidates, lower_prefix, "/shout", "Shout: message", true);
+    addCandidate(candidates, lower_prefix, "/whisper", "Whisper: message", true);
+
+    total = candidates.size();
+    for (const auto& candidate : candidates)
+    {
+        if (rows.size() == MAX_AUTOCOMPLETE_ROWS)
+        {
+            break;
+        }
+        rows.push_back(candidate.second);
+    }
+
+    return !rows.empty();
+}
+}
+
+void ALChatAutocomplete::update(
+    LLChatEntry* editor,
+    const std::string& prefix,
+    KEY key,
+    CommitCallback commit_cb)
+{
+    std::vector<LLGestureAutocompleteHelper::Row> rows;
+    size_t total = 0;
+
+    if (!buildRows(prefix, rows, total))
+    {
+        LLGestureAutocompleteHelper::instance().hideHelper(editor);
+        return;
+    }
+
+    LLGestureAutocompleteHelper::instance().showHelper(
+        editor,
+        rows,
+        total,
+        std::move(commit_cb));
+
+    const std::string& match = rows.front().value;
+    if (key < KEY_SPECIAL && match.size() > prefix.size())
+    {
+        editor->setText(prefix + match.substr(prefix.size()));
+        editor->selectByCursorPosition(
+            static_cast<S32>(prefix.size()),
+            static_cast<S32>(match.size()));
+    }
+}

--- a/indra/newview/alchatautocomplete.h
+++ b/indra/newview/alchatautocomplete.h
@@ -1,0 +1,35 @@
+/**
+ * @file alchatautocomplete.h
+ * @brief Gesture and command completion for nearby chat editors.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Alchemy Viewer Source Code
+ * Copyright (C) 2026, Alchemy Viewer Project.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ * $/LicenseInfo$
+ */
+
+#pragma once
+
+#include "llgestureautocompletehelper.h"
+
+#include <functional>
+#include <string>
+
+class LLChatEntry;
+
+namespace ALChatAutocomplete
+{
+using CommitAction = LLGestureAutocompleteHelper::CommitAction;
+using CommitCallback = std::function<void(const LLGestureAutocompleteHelper::Row&, CommitAction)>;
+
+void update(
+    LLChatEntry* editor,
+    const std::string& prefix,
+    KEY key,
+    CommitCallback commit_cb);
+}

--- a/indra/newview/alchatbar.cpp
+++ b/indra/newview/alchatbar.cpp
@@ -44,6 +44,7 @@
 #include "lltrans.h"
 #include "llchatentry.h"
 
+#include "alchatautocomplete.h"
 #include "alchatcommand.h"
 #include "llagent.h"
 #include "llbutton.h"
@@ -475,36 +476,21 @@ void ALChatBar::onInputEditorKeystroke(LLTextEditor* caller)
 
     KEY key = gKeyboard->currentKey();
 
-    // Ignore "special" keys, like backspace, arrows, etc.
-    // Ignore "special" keys, like backspace, arrows, etc.
-    if (gSavedSettings.getBOOL("ChatAutocompleteGestures")
-        && length > 1
-        && raw_text[0] == '/'
-        && key < KEY_SPECIAL)
-    {
-        // we're starting a gesture, attempt to autocomplete
-
-        std::string utf8_trigger = wstring_to_utf8str(raw_text);
-        std::string utf8_out_str(utf8_trigger);
-
-        if (LLGestureMgr::instance().matchPrefix(utf8_trigger, &utf8_out_str))
+    ALChatAutocomplete::update(
+        mInputEditor,
+        wstring_to_utf8str(raw_text),
+        key,
+        [this](const LLGestureAutocompleteHelper::Row& row, ALChatAutocomplete::CommitAction action)
         {
-            std::string rest_of_match = utf8_out_str.substr(utf8_trigger.size());
-            if (!rest_of_match.empty())
+            if (action == ALChatAutocomplete::CommitAction::SUBMIT)
             {
-                mInputEditor->setText(utf8_trigger + rest_of_match); // keep original capitalization for user-entered part
-                // Select to end of line, starting from the character
-                // after the last one the user typed.
-                mInputEditor->selectByCursorPosition(static_cast<S32>(utf8_out_str.size() - rest_of_match.size()), static_cast<S32>(utf8_out_str.size()));
+                sendChat(CHAT_TYPE_NORMAL);
+                return;
             }
 
-        }
-
-        //LL_INFOS() << "GESTUREDEBUG " << trigger
-        //  << " len " << length
-        //  << " outlen " << out_str.getLength()
-        //  << LL_ENDL;
-    }
+            mInputEditor->setText(row.value + " ");
+            mInputEditor->endOfDoc();
+        });
 }
 
 // static

--- a/indra/newview/alchatcommand.cpp
+++ b/indra/newview/alchatcommand.cpp
@@ -51,9 +51,81 @@
 #include "llvolume.h"
 #include "llvolumemessage.h"
 
+#include <iterator>
+
+namespace
+{
+constexpr char COMMAND_AO[] = "AlchemyChatCommandAnimationOverride";
+constexpr char COMMAND_CALC[] = "AlchemyChatCommandCalc";
+constexpr char COMMAND_CLEAR[] = "AlchemyChatCommandClearNearby";
+constexpr char COMMAND_DRAW_DISTANCE[] = "AlchemyChatCommandDrawDistance";
+constexpr char COMMAND_ENABLE[] = "AlchemyChatCommandEnable";
+constexpr char COMMAND_GROUND[] = "AlchemyChatCommandGround";
+constexpr char COMMAND_HEIGHT[] = "AlchemyChatCommandHeight";
+constexpr char COMMAND_HOME[] = "AlchemyChatCommandHome";
+constexpr char COMMAND_HOVER_HEIGHT[] = "AlchemyChatCommandHoverHeight";
+constexpr char COMMAND_MAP_TO[] = "AlchemyChatCommandMapto";
+constexpr char COMMAND_POSITION[] = "AlchemyChatCommandPos";
+constexpr char COMMAND_REGION_MESSAGE[] = "AlchemyChatCommandRegionMessage";
+constexpr char COMMAND_RESYNC_ANIMATIONS[] = "AlchemyChatCommandResyncAnim";
+constexpr char COMMAND_REZ_PLATFORM[] = "AlchemyChatCommandRezPlat";
+constexpr char COMMAND_SET_CHAT_CHANNEL[] = "AlchemyChatCommandSetChatChannel";
+constexpr char COMMAND_SET_HOME[] = "AlchemyChatCommandSetHome";
+constexpr char COMMAND_TELEPORT_TO_CAMERA[] = "AlchemyChatCommandTeleportToCam";
+constexpr char DICE_ROLL_TRIGGER[] = "/droll";
+constexpr char SEND_MENU_TRIGGER[] = "/sendmenu";
+
+struct ConfiguredCommand
+{
+    const char* setting;
+    const char* description;
+    bool accepts_arguments;
+};
+
+constexpr ConfiguredCommand CONFIGURED_COMMANDS[] = {
+    { COMMAND_AO, "Animation override: on|off|sit [on|off]", true },
+    { COMMAND_CALC, "Calculate: expression", true },
+    { COMMAND_CLEAR, "Clear nearby chat", false },
+    { COMMAND_DRAW_DISTANCE, "Set draw distance: meters", true },
+    { COMMAND_GROUND, "Teleport to ground", false },
+    { COMMAND_HEIGHT, "Teleport to height: meters", true },
+    { COMMAND_HOME, "Teleport home", false },
+    { COMMAND_HOVER_HEIGHT, "Set hover height: meters", true },
+    { COMMAND_MAP_TO, "Teleport to region: name", true },
+    { COMMAND_POSITION, "Teleport to position: x y z", true },
+    { COMMAND_REGION_MESSAGE, "Send region message: message", true },
+    { COMMAND_RESYNC_ANIMATIONS, "Resync animations", false },
+    { COMMAND_REZ_PLATFORM, "Rez a platform: [size]", true },
+    { COMMAND_SET_CHAT_CHANNEL, "Set nearby chat channel: channel", true },
+    { COMMAND_SET_HOME, "Set home location", false },
+    { COMMAND_TELEPORT_TO_CAMERA, "Teleport to camera", false },
+};
+}
+
+std::vector<ALChatCommand::AutocompleteCommand> ALChatCommand::getAutocompleteCommands()
+{
+    if (!gSavedSettings.getBOOL(COMMAND_ENABLE))
+    {
+        return {};
+    }
+
+    std::vector<AutocompleteCommand> commands;
+    commands.reserve(std::size(CONFIGURED_COMMANDS) + 2);
+    for (const ConfiguredCommand& command : CONFIGURED_COMMANDS)
+    {
+        commands.push_back({
+            gSavedSettings.getString(command.setting),
+            command.description,
+            command.accepts_arguments });
+    }
+    commands.push_back({ DICE_ROLL_TRIGGER, "Roll a die: [sides]", true });
+    commands.push_back({ SEND_MENU_TRIGGER, "Reply to a dialog menu: channel button", true });
+    return commands;
+}
+
 bool ALChatCommand::parseCommand(std::string data)
 {
-    static LLCachedControl<bool> enableChatCmd(gSavedSettings, "AlchemyChatCommandEnable", true);
+    static LLCachedControl<bool> enableChatCmd(gSavedSettings, COMMAND_ENABLE, true);
     if (enableChatCmd)
     {
         utf8str_tolower(data);
@@ -62,22 +134,22 @@ bool ALChatCommand::parseCommand(std::string data)
 
         if (!(input >> cmd))    return false;
 
-        static LLCachedControl<std::string> sDrawDistanceCommand(gSavedSettings, "AlchemyChatCommandDrawDistance", "/dd");
-        static LLCachedControl<std::string> sHeightCommand(gSavedSettings, "AlchemyChatCommandHeight", "/gth");
-        static LLCachedControl<std::string> sGroundCommand(gSavedSettings, "AlchemyChatCommandGround", "/flr");
-        static LLCachedControl<std::string> sPosCommand(gSavedSettings, "AlchemyChatCommandPos", "/pos");
-        static LLCachedControl<std::string> sRezPlatCommand(gSavedSettings, "AlchemyChatCommandRezPlat", "/plat");
-        static LLCachedControl<std::string> sHomeCommand(gSavedSettings, "AlchemyChatCommandHome", "/home");
-        static LLCachedControl<std::string> sSetHomeCommand(gSavedSettings, "AlchemyChatCommandSetHome", "/sethome");
-        static LLCachedControl<std::string> sCalcCommand(gSavedSettings, "AlchemyChatCommandCalc", "/calc");
-        static LLCachedControl<std::string> sMaptoCommand(gSavedSettings, "AlchemyChatCommandMapto", "/mapto");
-        static LLCachedControl<std::string> sClearCommand(gSavedSettings, "AlchemyChatCommandClearNearby", "/clr");
-        static LLCachedControl<std::string> sRegionMsgCommand(gSavedSettings, "AlchemyChatCommandRegionMessage", "/regionmsg");
-        static LLCachedControl<std::string> sSetNearbyChatChannelCmd(gSavedSettings, "AlchemyChatCommandSetChatChannel", "/setchannel");
-        static LLCachedControl<std::string> sResyncAnimCommand(gSavedSettings, "AlchemyChatCommandResyncAnim", "/resync");
-        static LLCachedControl<std::string> sTeleportToCam(gSavedSettings, "AlchemyChatCommandTeleportToCam", "/tp2cam");
-        static LLCachedControl<std::string> sHoverHeight(gSavedSettings, "AlchemyChatCommandHoverHeight", "/hover");
-        static LLCachedControl<std::string> sAOCommand(gSavedSettings, "AlchemyChatCommandAnimationOverride", "/ao");
+        static LLCachedControl<std::string> sDrawDistanceCommand(gSavedSettings, COMMAND_DRAW_DISTANCE, "/dd");
+        static LLCachedControl<std::string> sHeightCommand(gSavedSettings, COMMAND_HEIGHT, "/gth");
+        static LLCachedControl<std::string> sGroundCommand(gSavedSettings, COMMAND_GROUND, "/flr");
+        static LLCachedControl<std::string> sPosCommand(gSavedSettings, COMMAND_POSITION, "/pos");
+        static LLCachedControl<std::string> sRezPlatCommand(gSavedSettings, COMMAND_REZ_PLATFORM, "/plat");
+        static LLCachedControl<std::string> sHomeCommand(gSavedSettings, COMMAND_HOME, "/home");
+        static LLCachedControl<std::string> sSetHomeCommand(gSavedSettings, COMMAND_SET_HOME, "/sethome");
+        static LLCachedControl<std::string> sCalcCommand(gSavedSettings, COMMAND_CALC, "/calc");
+        static LLCachedControl<std::string> sMaptoCommand(gSavedSettings, COMMAND_MAP_TO, "/mapto");
+        static LLCachedControl<std::string> sClearCommand(gSavedSettings, COMMAND_CLEAR, "/clr");
+        static LLCachedControl<std::string> sRegionMsgCommand(gSavedSettings, COMMAND_REGION_MESSAGE, "/regionmsg");
+        static LLCachedControl<std::string> sSetNearbyChatChannelCmd(gSavedSettings, COMMAND_SET_CHAT_CHANNEL, "/setchannel");
+        static LLCachedControl<std::string> sResyncAnimCommand(gSavedSettings, COMMAND_RESYNC_ANIMATIONS, "/resync");
+        static LLCachedControl<std::string> sTeleportToCam(gSavedSettings, COMMAND_TELEPORT_TO_CAMERA, "/tp2cam");
+        static LLCachedControl<std::string> sHoverHeight(gSavedSettings, COMMAND_HOVER_HEIGHT, "/hover");
+        static LLCachedControl<std::string> sAOCommand(gSavedSettings, COMMAND_AO, "/ao");
 
         if (cmd == utf8str_tolower(sDrawDistanceCommand()))  // dd
         {
@@ -216,7 +288,7 @@ bool ALChatCommand::parseCommand(std::string data)
             }
             return true;
         }
-        else if (cmd == "/droll")
+        else if (cmd == DICE_ROLL_TRIGGER)
         {
             S32 dice_sides;
             if (!(input >> dice_sides))
@@ -326,7 +398,7 @@ bool ALChatCommand::parseCommand(std::string data)
                 }
             }
         }
-        else if (cmd == "/sendmenu")
+        else if (cmd == SEND_MENU_TRIGGER)
         {
             S32 channel;
             if (!(input >> channel))

--- a/indra/newview/alchatcommand.h
+++ b/indra/newview/alchatcommand.h
@@ -22,8 +22,19 @@
 
 #include "linden_common.h"
 
+#include <string>
+#include <vector>
+
 namespace ALChatCommand
 {
+    struct AutocompleteCommand
+    {
+        std::string trigger;
+        std::string description;
+        bool accepts_arguments;
+    };
+
+    std::vector<AutocompleteCommand> getAutocompleteCommands();
     bool parseCommand(std::string data);
 };
 

--- a/indra/newview/llfloatergestureautocompletepicker.cpp
+++ b/indra/newview/llfloatergestureautocompletepicker.cpp
@@ -43,7 +43,7 @@ bool LLFloaterGestureAutocompletePicker::postBuild()
 {
     mGestureList = getChild<LLScrollListCtrl>("gesture_list");
     mGestureList->setCommitOnKeyboardMovement(false);
-    mGestureList->setCommitCallback(boost::bind(&LLFloaterGestureAutocompletePicker::commitSelected, this));
+    mGestureList->setCommitCallback(boost::bind(&LLFloaterGestureAutocompletePicker::commitSelected, this, false));
 
     return LLFloater::postBuild();
 }
@@ -101,6 +101,8 @@ bool LLFloaterGestureAutocompletePicker::handleKey(KEY key, MASK mask, bool call
                 mGestureList->scrollToShowSelected();
                 return true;
             case KEY_RETURN:
+                commitSelected(true);
+                return true;
             case KEY_TAB:
                 commitSelected();
                 return true;
@@ -131,7 +133,7 @@ void LLFloaterGestureAutocompletePicker::goneFromFront()
     LLGestureAutocompleteHelper::instance().hideHelper();
 }
 
-bool LLFloaterGestureAutocompletePicker::commitSelected()
+bool LLFloaterGestureAutocompletePicker::commitSelected(bool return_key)
 {
     LLScrollListItem* item = mGestureList->getFirstSelected();
 
@@ -147,8 +149,7 @@ bool LLFloaterGestureAutocompletePicker::commitSelected()
         return false;
     }
 
-    setValue(value);
-    onCommit();
+    LLGestureAutocompleteHelper::instance().onCommit(value, return_key);
 
     return true;
 }

--- a/indra/newview/llfloatergestureautocompletepicker.h
+++ b/indra/newview/llfloatergestureautocompletepicker.h
@@ -41,7 +41,7 @@ public:
     void goneFromFront() override;
 
 private:
-    bool commitSelected();
+    bool commitSelected(bool return_key = false);
 
     LLScrollListCtrl* mGestureList;
 };

--- a/indra/newview/llfloaterimnearbychat.cpp
+++ b/indra/newview/llfloaterimnearbychat.cpp
@@ -75,9 +75,8 @@
 #include "rlvcommon.h"
 #include "rlvhandler.h"
 // [/RLVa:KB]
+#include "alchatautocomplete.h"
 #include "alchatcommand.h"
-
-#include <map>
 
 S32 LLFloaterIMNearbyChat::sLastSpecialChatChannel = 0;
 
@@ -86,67 +85,6 @@ static LLFloaterIMNearbyChatListener sChatListener;
 constexpr S32 EXPANDED_HEIGHT = 266;
 constexpr S32 COLLAPSED_HEIGHT = 60;
 constexpr S32 EXPANDED_MIN_HEIGHT = 150;
-constexpr size_t MAX_GESTURE_AUTOCOMPLETE_ROWS = 50;
-
-namespace
-{
-bool buildGestureAutocompleteRows(
-    const std::string& prefix,
-    std::vector<LLGestureAutocompleteHelper::Row>& rows,
-    size_t& total)
-{
-    rows.clear();
-    total = 0;
-
-    // Wait for at least one character after the slash before offering matches.
-    if (prefix.size() < 2 || prefix[0] != '/' || prefix.find_first_of(" \t") != std::string::npos)
-    {
-        return false;
-    }
-
-    std::string lower_prefix = prefix;
-    LLStringUtil::toLower(lower_prefix);
-
-    std::map<std::string, std::string> unique;
-    const LLGestureMgr::item_map_t& active = LLGestureMgr::instance().getActiveGestures();
-
-    for (const auto& entry : active)
-    {
-        LLMultiGesture* gesture = entry.second;
-
-        if (!gesture || gesture->getTrigger().empty() || gesture->getTrigger()[0] != '/')
-        {
-            continue;
-        }
-
-        std::string lower_trigger = gesture->getTrigger();
-        LLStringUtil::toLower(lower_trigger);
-
-        if (lower_trigger.compare(0, lower_prefix.size(), lower_prefix) != 0)
-        {
-            continue;
-        }
-
-        unique.emplace(
-            gesture->getTrigger(),
-            gesture->mName);
-    }
-
-    for (const auto& [trigger, name] : unique)
-    {
-        if (rows.size() >= MAX_GESTURE_AUTOCOMPLETE_ROWS)
-        {
-            break;
-        }
-
-        rows.push_back({ trigger, trigger, name });
-    }
-
-    total = unique.size();
-
-    return total > 0;
-}
-}
 
 // legacy callback glue
 //void send_chat_from_viewer(const std::string& utf8_out_text, EChatType type, S32 channel);
@@ -656,65 +594,21 @@ void LLFloaterIMNearbyChat::onChatBoxKeystroke()
 
     KEY key = gKeyboard->currentKey();
 
-    static LLCachedControl<bool> autocomplete_gestures(gSavedSettings, "ChatAutocompleteGestures", true);
-
-    if (autocomplete_gestures)
-    {
-        std::vector<LLGestureAutocompleteHelper::Row> rows;
-        size_t total = 0;
-        const std::string utf8_trigger = wstring_to_utf8str(raw_text);
-
-        if (buildGestureAutocompleteRows(utf8_trigger, rows, total))
+    ALChatAutocomplete::update(
+        mInputEditor,
+        wstring_to_utf8str(raw_text),
+        key,
+        [this](const LLGestureAutocompleteHelper::Row& row, ALChatAutocomplete::CommitAction action)
         {
-            LLGestureAutocompleteHelper::instance().showHelper(
-                mInputEditor,
-                rows,
-                total,
-                [this](std::string trigger)
-                {
-                    mInputEditor->setText(trigger + " ");
-                    mInputEditor->endOfDoc();
-                });
-            return;
-        }
-
-        LLGestureAutocompleteHelper::instance().hideHelper(mInputEditor);
-    }
-    // Ignore "special" keys, like backspace, arrows, etc.
-    if (autocomplete_gestures
-        && length > 1
-        && raw_text[0] == '/'
-        && key < KEY_SPECIAL)
-    {
-        // we're starting a gesture, attempt to autocomplete
-
-        std::string utf8_trigger = wstring_to_utf8str(raw_text);
-        std::string utf8_out_str(utf8_trigger);
-
-        if (LLGestureMgr::instance().matchPrefix(utf8_trigger, &utf8_out_str))
-        {
-            std::string rest_of_match = utf8_out_str.substr(utf8_trigger.size());
-            if (!rest_of_match.empty())
+            if (action == ALChatAutocomplete::CommitAction::SUBMIT)
             {
-                mInputEditor->setText(utf8_trigger + rest_of_match); // keep original capitalization for user-entered part
-                // Select to end of line, starting from the character
-                // after the last one the user typed.
-                mInputEditor->selectByCursorPosition(static_cast<S32>(utf8_out_str.size() - rest_of_match.size()), static_cast<S32>(utf8_out_str.size()));
+                sendChat(CHAT_TYPE_NORMAL);
+                return;
             }
 
-        }
-        else if (matchChatTypeTrigger(utf8_trigger, &utf8_out_str))
-        {
-            std::string rest_of_match = utf8_out_str.substr(utf8_trigger.size());
-            mInputEditor->setText(utf8_trigger + rest_of_match + " "); // keep original capitalization for user-entered part
+            mInputEditor->setText(row.value + " ");
             mInputEditor->endOfDoc();
-        }
-
-        //LL_INFOS() << "GESTUREDEBUG " << trigger
-        //  << " len " << length
-        //  << " outlen " << out_str.getLength()
-        //  << LL_ENDL;
-    }
+        });
 }
 
 // static

--- a/indra/newview/skins/default/xui/en/floater_gesture_autocomplete_picker.xml
+++ b/indra/newview/skins/default/xui/en/floater_gesture_autocomplete_picker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <floater
  name="gesture_autocomplete_picker"
- title="CHOOSE GESTURE"
+ title="CHOOSE COMPLETION"
  single_instance="true"
  can_minimize="false"
  can_tear_off="false"
@@ -33,7 +33,7 @@
         width="128" />
        <scroll_list.columns
         name="name"
-        label="Gesture"
+        label="Description"
         dynamic_width="true" />
    </scroll_list>
 </floater>


### PR DESCRIPTION
This PR brings the upstream chat gesture completion I contributed inline with Alchemy, by providing support for the nearby chat bar, and support for chat commands if they're prefixed with `/`.

<img width="440" height="211" alt="image" src="https://github.com/user-attachments/assets/418705de-e7cf-4f67-8f95-237b3bda44ec" />