### PR TITLE
Introduce temporary workaround for SDL3 libdecor

### DIFF
--- a/indra/cmake/triplets/x64-linux-alchemy.cmake
+++ b/indra/cmake/triplets/x64-linux-alchemy.cmake
@@ -7,3 +7,10 @@ set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 if(PORT MATCHES "^webrtc$")
     set(VCPKG_BUILD_TYPE release)
 endif()
+
+# SDL3's upstream vcpkg port introduced a regression which explicitly disables libdecor, causing GNOME Wayland
+# windows to have no decorations. Append ON after the portfile's OFF so cmake's
+# last-value-wins rule applies. Remove once upstream vcpkg regression is fixed.
+if(PORT STREQUAL "sdl3")
+    list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS "-DSDL_WAYLAND_LIBDECOR=ON")
+endif()


### PR DESCRIPTION
## Description

Upstream SDL3 has introduced a regression which disables libdecor support by default. Until this is fixed upstream, this provides a workaround.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
