### PR TITLE
Linux: fix CEF resource staging and media_plugin_cef rpath after vcpkg migration

### DIFF
--- a/indra/cmake/triplets/x64-linux-alchemy.cmake
+++ b/indra/cmake/triplets/x64-linux-alchemy.cmake
@@ -7,3 +7,10 @@ set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 if(PORT MATCHES "^webrtc$")
     set(VCPKG_BUILD_TYPE release)
 endif()
+
+# SDL3's upstream vcpkg port introduced a regression which explicitly disables libdecor, causing GNOME Wayland
+# windows to have no decorations. Append ON after the portfile's OFF so cmake's
+# last-value-wins rule applies. Remove once upstream vcpkg regression is fixed.
+if(PORT STREQUAL "sdl3")
+    list(APPEND VCPKG_CMAKE_CONFIGURE_OPTIONS "-DSDL_WAYLAND_LIBDECOR=ON")
+endif()

--- a/indra/media_plugins/cef/CMakeLists.txt
+++ b/indra/media_plugins/cef/CMakeLists.txt
@@ -201,11 +201,7 @@ elseif (LINUX)
     "${CEF_RESOURCE_DIR}/resources.pak"
     "${CEF_RESOURCE_DIR}/icudtl.dat"
   )
-  add_custom_command(
-    TARGET media_plugin_cef POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CEF_RESOURCE_FILES} "${VIEWER_STAGING_DIR}/bin/llplugin"
-    COMMAND_EXPAND_LISTS
-  )
+
   add_custom_command(
     TARGET media_plugin_cef POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different "${CEF_RESOURCE_DIR}/locales" "${VIEWER_STAGING_DIR}/bin/llplugin/locales"

--- a/indra/media_plugins/cef/CMakeLists.txt
+++ b/indra/media_plugins/cef/CMakeLists.txt
@@ -203,6 +203,7 @@ elseif (LINUX)
   )
   add_custom_command(
     TARGET media_plugin_cef POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${VIEWER_STAGING_DIR}/bin/llplugin"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CEF_RESOURCE_FILES} "${VIEWER_STAGING_DIR}/bin/llplugin"
     COMMAND_EXPAND_LISTS
   )

--- a/indra/media_plugins/cef/CMakeLists.txt
+++ b/indra/media_plugins/cef/CMakeLists.txt
@@ -201,7 +201,11 @@ elseif (LINUX)
     "${CEF_RESOURCE_DIR}/resources.pak"
     "${CEF_RESOURCE_DIR}/icudtl.dat"
   )
-
+  add_custom_command(
+    TARGET media_plugin_cef POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CEF_RESOURCE_FILES} "${VIEWER_STAGING_DIR}/bin/llplugin"
+    COMMAND_EXPAND_LISTS
+  )
   add_custom_command(
     TARGET media_plugin_cef POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different "${CEF_RESOURCE_DIR}/locales" "${VIEWER_STAGING_DIR}/bin/llplugin/locales"

--- a/indra/media_plugins/cef/CMakeLists.txt
+++ b/indra/media_plugins/cef/CMakeLists.txt
@@ -211,10 +211,12 @@ elseif (LINUX)
     COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different "${CEF_RESOURCE_DIR}/locales" "${VIEWER_STAGING_DIR}/bin/llplugin/locales"
   )
 
-  add_custom_command(
-    TARGET media_plugin_cef POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${VIEWER_STAGING_DIR}/lib"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CEF_BIN_FILES} "${VIEWER_STAGING_DIR}/lib"
-    COMMAND_EXPAND_LISTS
-  )
+  if (CEF_BIN_FILES)
+    add_custom_command(
+      TARGET media_plugin_cef POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${VIEWER_STAGING_DIR}/lib"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CEF_BIN_FILES} "${VIEWER_STAGING_DIR}/lib"
+      COMMAND_EXPAND_LISTS
+    )
+  endif ()
 endif ()

--- a/indra/media_plugins/cef/CMakeLists.txt
+++ b/indra/media_plugins/cef/CMakeLists.txt
@@ -194,4 +194,27 @@ elseif (DARWIN)
 
 elseif (LINUX)
   target_link_options(media_plugin_cef PRIVATE  "LINKER:--build-id" "LINKER:-rpath,'$ORIGIN:$ORIGIN/../../lib'")
+
+  set(CEF_RESOURCE_FILES
+    "${CEF_RESOURCE_DIR}/chrome_100_percent.pak"
+    "${CEF_RESOURCE_DIR}/chrome_200_percent.pak"
+    "${CEF_RESOURCE_DIR}/resources.pak"
+    "${CEF_RESOURCE_DIR}/icudtl.dat"
+  )
+  add_custom_command(
+    TARGET media_plugin_cef POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CEF_RESOURCE_FILES} "${VIEWER_STAGING_DIR}/bin/llplugin"
+    COMMAND_EXPAND_LISTS
+  )
+  add_custom_command(
+    TARGET media_plugin_cef POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different "${CEF_RESOURCE_DIR}/locales" "${VIEWER_STAGING_DIR}/bin/llplugin/locales"
+  )
+
+  add_custom_command(
+    TARGET media_plugin_cef POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${VIEWER_STAGING_DIR}/lib"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CEF_BIN_FILES} "${VIEWER_STAGING_DIR}/lib"
+    COMMAND_EXPAND_LISTS
+  )
 endif ()


### PR DESCRIPTION
## Description

Note: these changes also need https://github.com/AlchemyViewer/dullahan/pull/5 for a functional CEF implementation.

Two Linux fixes for issues introduced by the migration from manual library
resolution to find_package(unofficial-cef):

**Fix 1: CEF resource staging**
After the vcpkg migration, CEF resource files (.pak, icudtl.dat, locales)
were no longer being staged to bin/llplugin/ during CMake builds because
the old hardcoded _VCPKG_INSTALLED_DIR paths were removed. Add post-build
copy commands using CEF_RESOURCE_DIR and CEF_BINARY_DIR_RELEASE, which are
set by unofficial-cef-config.cmake, to restore this for dev builds.

**Fix 2: media_plugin_cef rpath**
Add a rpath of $ORIGIN:$ORIGIN/../../lib to media_plugin_cef so that
libcef.so can be found when CEF re-launches the host executable as a
renderer/GPU subprocess, where the working directory may differ from the
launch environment set up by the wrapper script.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
