### PR TITLE
Linux: unquote $ORIGIN in media_plugin_cef rpath linker option

### DIFF
--- a/indra/media_plugins/cef/CMakeLists.txt
+++ b/indra/media_plugins/cef/CMakeLists.txt
@@ -193,7 +193,7 @@ elseif (DARWIN)
     )
 
 elseif (LINUX)
-  target_link_options(media_plugin_cef PRIVATE  "LINKER:--build-id" "LINKER:-rpath,'$ORIGIN:$ORIGIN/../../lib'")
+  target_link_options(media_plugin_cef PRIVATE  "LINKER:--build-id" "LINKER:-rpath,\$ORIGIN:\$ORIGIN/../../lib")
 
   set(CEF_RESOURCE_FILES
     "${CEF_RESOURCE_DIR}/chrome_100_percent.pak"


### PR DESCRIPTION
## Problem
When specifying `-rpath` options with CMake's `"LINKER:..."` prefix in `target_link_options`, wrapping `$ORIGIN` in single quotes (`'$ORIGIN'`) passes the single quotes literally to the linker.

While GNU `ld` happens to strip nested quotation marks, modern linkers such as `mold` and `lld` preserve the single quotes literally into the ELF `DT_RUNPATH` header:
```
RUNPATH '$ORIGIN:$ORIGIN/../../lib'
```

glibc's dynamic loader (`ld.so`) only recognizes and expands tokens that start unquoted with `$` (or `${ORIGIN}`). When literal single quotes are embedded in the ELF header, `ld.so` treats the path as a literal directory named `'$ORIGIN'`, `$ORIGIN` expansion fails, and `media_plugin_cef` fails to locate `libcef.so` at runtime.

## Fix
Escaping the dollar sign without wrapping in single quotes (`"LINKER:-rpath,\$ORIGIN:\$ORIGIN/../../lib"`) ensures that CMake passes `-rpath` with unquoted `$ORIGIN` tokens across all linkers (`ld`, `lld`, `mold`), producing valid and portable `DT_RUNPATH` entries.