### PR TITLE
llaudio: fix audio thread race causing SIGILL crash in SDL audio thread

### DIFF
--- a/indra/llaudio/llaudioengine_faudio.cpp
+++ b/indra/llaudio/llaudioengine_faudio.cpp
@@ -1698,7 +1698,14 @@ bool LLAudioChannelFAudio::updateBuffer()
     auto* buf = static_cast<LLAudioBufferFAudio*>(mCurrentSourcep->getCurrentBuffer());
     if (!buf) return false;
 
-    if (buffer_changed || !mVoice)
+    if (buffer_changed)
+    {
+        if (mVoice && !mVoiceUsesFilter)
+            destroyVoice();
+        else
+            retireVoice();
+    }
+    if (!mVoice)
     {
         // A genuine buffer swap makes any stashed resume offset stale —
         // it was a frame count for the old buffer's length, not this

--- a/indra/llaudio/llaudioengine_faudio.cpp
+++ b/indra/llaudio/llaudioengine_faudio.cpp
@@ -1698,7 +1698,11 @@ bool LLAudioChannelFAudio::updateBuffer()
     auto* buf = static_cast<LLAudioBufferFAudio*>(mCurrentSourcep->getCurrentBuffer());
     if (!buf) return false;
 
-    if (buffer_changed || !mVoice)
+    if (buffer_changed)
+    {
+        retireVoice();
+    }
+    if (!mVoice)
     {
         // A genuine buffer swap makes any stashed resume offset stale —
         // it was a frame count for the old buffer's length, not this

--- a/indra/llaudio/lllistener_faudio.cpp
+++ b/indra/llaudio/lllistener_faudio.cpp
@@ -535,8 +535,16 @@ namespace
                                                    channel->mSmoothedDoppler));
         const float log_next   = log_curr + (log_target - log_curr) * kSmoothAlpha;
         channel->mSmoothedDoppler = std::exp(log_next);
-        FAudioSourceVoice_SetFrequencyRatio(voice, channel->mSmoothedDoppler,
-                                            FAUDIO_COMMIT_NOW);
+        // Defer SetFrequencyRatio via an operation set rather than FAUDIO_COMMIT_NOW.
+        // Writing freqRatio immediately from the main thread races with the SDL
+        // audio thread reading it in FAudio_INTERNAL_MixSource during the window
+        // where sourceLock is released to fire OnVoiceProcessingPassStart.
+        // A unique per-call counter avoids colliding with any other pending set.
+        static uint32_t s_opset_counter = 0;
+        if (++s_opset_counter == FAUDIO_COMMIT_NOW) ++s_opset_counter;
+        const uint32_t opset = s_opset_counter;
+        FAudioSourceVoice_SetFrequencyRatio(voice, channel->mSmoothedDoppler, opset);
+        FAudio_CommitOperationSet(engine->getFAudio(), opset);
     }
 }
 


### PR DESCRIPTION
## Description

Two related fixes for a SIGILL crash in the SDL audio thread 
(FAudio_INTERNAL_DecodeBuffers), reproducible on Linux/PipeWire.

**Root cause**
FAudioSourceVoice_SetFrequencyRatio with FAUDIO_COMMIT_NOW writes
voice->src.freqRatio from the main thread without holding sourceLock.
The SDL audio thread releases sourceLock briefly during
OnVoiceProcessingPassStart before re-reading freqRatio to recalculate
resampleStep and toDecode. This produces either a uint64_t underflow
(toDecode wraps to a huge value) or a failed assert on decodeSamples.

**Fix 1 — lllistener_faudio.cpp**
Defer SetFrequencyRatio via a unique operation set rather than
FAUDIO_COMMIT_NOW. The write is queued and only applied at a safe
point in the next mix cycle, outside the sourceLock release window.
SetFilterParameters and SetOutputMatrix remain as FAUDIO_COMMIT_NOW —
deferring SetOutputMatrix was found to cause looping sounds to
unexpectedly stop.

**Fix 2 — llaudioengine_faudio.cpp**
Retire the voice explicitly when the buffer changes in updateBuffer,
rather than relying on the combined (buffer_changed || !mVoice)
condition. Prevents stale voice state from persisting when the source
moves to a new buffer, which could interact with the timing issues
above.

A companion patch to the FAudio library itself (adding sourceLock
around the freqRatio write in SetFrequencyRatio) has been submitted
to the alchemy-registry as a vcpkg port patch (found at https://github.com/AlchemyViewer/alchemy-registry/pull/3 )

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
