### PR TITLE
Lens flare: stop the strobe with a temporally filtered state pass

### DIFF
--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -105,7 +105,7 @@ The deferred rendering pipeline is orchestrated by `LLPipeline` (`indra/newview/
 
 **Post-processing chain:**
 - **Auto-exposure:** Progressive histogram (`gLuminanceProgram`, `gExposureProgram`) with history fade
-- **Lens flare sun state:** a 2x1 temporal pass (`gLensFlareStateProgram`, `lensFlareStateF.glsl`) run just before colour correction measures how much of the sun disc is unoccluded and its colour, and filters both over time under a rate limit; `computeLensFlare` in `postEffectUtilsF.glsl` reads one texel of it instead of probing depth per fragment. Constants come from `scripts/content_tools/check_lens_flare_state.py`
+- **Lens flare sun state:** a 2x1 temporal pass (`gLensFlareStateProgram`, `lensFlareStateF.glsl`) run just before colour correction measures how much of the sun disc is unoccluded and its colour, and filters both under a rate limit; `computeLensFlare` in `postEffectUtilsF.glsl` reads one texel of it. The shader is the source of truth for the filter; `scripts/content_tools/check_lens_flare_state.py` mirrors it and is its regression test
 - **Bloom:** Bright-area extraction → 3-level glow pyramid (`mGlow[3]`) with warmth correction
 - **Depth of Field:** Circle-of-confusion via `gDeferredCoFProgram`, combine via `gDeferredDoFCombineProgram`. Settings: `CameraFNumber`, `CameraFocalLength`, `CameraMaxCoF`
 - **Screen Space Reflections:** Class 3+ feature, iterative ray marching

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -105,6 +105,7 @@ The deferred rendering pipeline is orchestrated by `LLPipeline` (`indra/newview/
 
 **Post-processing chain:**
 - **Auto-exposure:** Progressive histogram (`gLuminanceProgram`, `gExposureProgram`) with history fade
+- **Lens flare sun state:** a 2x1 temporal pass (`gLensFlareStateProgram`, `lensFlareStateF.glsl`) run just before colour correction measures how much of the sun disc is unoccluded and its colour, and filters both over time under a rate limit; `computeLensFlare` in `postEffectUtilsF.glsl` reads one texel of it instead of probing depth per fragment. Constants come from `scripts/content_tools/check_lens_flare_state.py`
 - **Bloom:** Bright-area extraction → 3-level glow pyramid (`mGlow[3]`) with warmth correction
 - **Depth of Field:** Circle-of-confusion via `gDeferredCoFProgram`, combine via `gDeferredDoFCombineProgram`. Settings: `CameraFNumber`, `CameraFocalLength`, `CameraMaxCoF`
 - **Screen Space Reflections:** Class 3+ feature, iterative ray marching

--- a/doc/LIGHTBOX.md
+++ b/doc/LIGHTBOX.md
@@ -810,12 +810,14 @@ only; apply per row, not on the parent panel. Reference patterns:
 - **`gSnapshotNoPost` gates the renderer, not the UI, and it is easy to miss.**
   The snapshot floater's "No post-processing" box has to mean it, so a new
   *print* effect must check it wherever its strength is uploaded — there are
-  `clean_plate` gates in **two** places, because post-grade is two passes.
-  Effects in the final blit (vignette, grain, CVD, the preview modes) gate in
-  `renderFinalize`; effects applied *inside* the colorCorrect program
-  (chromatic aberration, lens flare) gate in `colorCorrect`, because they run
-  in every variant including the no-post ones — those two leaked through the
-  first time for exactly that reason. The one deliberate exception is dither,
+  `clean_plate` gates in **three** places. Effects in the final blit (vignette,
+  grain, CVD, the preview modes) gate in `renderFinalize`; effects applied
+  *inside* the colorCorrect program (chromatic aberration, lens flare) gate in
+  `colorCorrect`, because they run in every variant including the no-post
+  ones — those two leaked through the first time for exactly that reason; and
+  `generateLensFlareState`, which owns the flare's history, skips its update
+  on a no-post frame rather than clearing it, so the flare does not blink
+  after the capture. The one deliberate exception is dither,
   which is a quantisation aid rather than a look and which an 8-bit PNG wants
   either way.
 

--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -1916,8 +1916,9 @@ void LLShaderMgr::initAttribsAndUniforms()
     mReservedUniforms.push_back("uLensFlareStarburstSpikes");
     mReservedUniforms.push_back("uLensFlareStarburstSharpness");
     mReservedUniforms.push_back("uLensFlareStarburstFalloff");
-    mReservedUniforms.push_back("uLensFlareOcclusionTaps");
     mReservedUniforms.push_back("uLensFlareLightColor");
+    mReservedUniforms.push_back("uLensFlareStateMap");
+    mReservedUniforms.push_back("uLensFlareFadeParams");
 
     // Color Correction LUT
     mReservedUniforms.push_back("uColorGradeLut");

--- a/indra/llrender/llshadermgr.cpp
+++ b/indra/llrender/llshadermgr.cpp
@@ -1918,7 +1918,7 @@ void LLShaderMgr::initAttribsAndUniforms()
     mReservedUniforms.push_back("uLensFlareStarburstFalloff");
     mReservedUniforms.push_back("uLensFlareLightColor");
     mReservedUniforms.push_back("uLensFlareStateMap");
-    mReservedUniforms.push_back("uLensFlareFadeParams");
+    mReservedUniforms.push_back("uLensFlareFadeTime");
 
     // Color Correction LUT
     mReservedUniforms.push_back("uColorGradeLut");

--- a/indra/llrender/llshadermgr.h
+++ b/indra/llrender/llshadermgr.h
@@ -423,7 +423,7 @@ public:
         // Lens Flare
         LENS_FLARE_STRENGTH,                //  "uLensFlareStrength"
         LENS_FLARE_SUN_POS,                 //  "uLensFlareSunPos"
-        LENS_FLARE_SUN_VISIBILITY,          //  "uLensFlareSunVisibility"
+        LENS_FLARE_SUN_VISIBILITY,          //  "uLensFlareSunVisibility"  CPU screen-edge fade, an input to the state pass
         LENS_FLARE_STREAK_LENGTH,           //  "uLensFlareStreakLength"
         LENS_FLARE_STREAK_FALLOFF,          //  "uLensFlareStreakFalloff"
         LENS_FLARE_STREAK_WIDTH,            //  "uLensFlareStreakWidth"
@@ -439,13 +439,14 @@ public:
         LENS_FLARE_HALO_RADIUS,             //  "uLensFlareHaloRadius"
         LENS_FLARE_HALO_WIDTH,              //  "uLensFlareHaloWidth"
         LENS_FLARE_HALO,                    //  "uLensFlareHalo"
-        LENS_FLARE_OCCLUSION_RADIUS,        //  "uLensFlareOcclusionRadius"
+        LENS_FLARE_OCCLUSION_RADIUS,        //  "uLensFlareOcclusionRadius"  probe radius, fraction of screen height
         LENS_FLARE_STARBURST,               //  "uLensFlareStarburst"
         LENS_FLARE_STARBURST_SPIKES,        //  "uLensFlareStarburstSpikes"
         LENS_FLARE_STARBURST_SHARPNESS,     //  "uLensFlareStarburstSharpness"
         LENS_FLARE_STARBURST_FALLOFF,       //  "uLensFlareStarburstFalloff"
-        LENS_FLARE_OCCLUSION_TAPS,          //  "uLensFlareOcclusionTaps"
         LENS_FLARE_LIGHT_COLOR,             //  "uLensFlareLightColor"
+        LENS_FLARE_STATE_MAP,               //  "uLensFlareStateMap"    2x1 written by generateLensFlareState
+        LENS_FLARE_FADE_PARAMS,             //  "uLensFlareFadeParams"  (tau_in, tau_out, slew_in, slew_out)
 
         // Color Correction LUT
         COLOR_GRADE_LUT,                    //  "uColorGradeLut"

--- a/indra/llrender/llshadermgr.h
+++ b/indra/llrender/llshadermgr.h
@@ -446,7 +446,7 @@ public:
         LENS_FLARE_STARBURST_FALLOFF,       //  "uLensFlareStarburstFalloff"
         LENS_FLARE_LIGHT_COLOR,             //  "uLensFlareLightColor"
         LENS_FLARE_STATE_MAP,               //  "uLensFlareStateMap"    2x1 written by generateLensFlareState
-        LENS_FLARE_FADE_PARAMS,             //  "uLensFlareFadeParams"  (tau_in, tau_out, slew_in, slew_out)
+        LENS_FLARE_FADE_TIME,               //  "uLensFlareFadeTime"    RenderLensFlareFadeTime, seconds; the shader derives its rates
 
         // Color Correction LUT
         COLOR_GRADE_LUT,                    //  "uColorGradeLut"

--- a/indra/newview/app_settings/looks/Golden%20Hour.xml
+++ b/indra/newview/app_settings/looks/Golden%20Hour.xml
@@ -811,27 +811,27 @@
             <key>Value</key>
             <real>0.15</real>
         </map>
-        <key>RenderLensFlareOcclusionRadius</key>
+        <key>RenderLensFlareOcclusionScale</key>
         <map>
             <key>Comment</key>
-            <string>How wide the sun-occlusion test samples the scene depth. Larger values let thin geometry (foliage, wires) dim the flare more gracefully. Range 0.005 to 0.1.</string>
+            <string>Size of the sun-occlusion probe as a multiple of the sun disc; it follows zoom and the sky's sun scale. Below 1 only the core of the disc counts, above 1 objects near the sun start to dim the flare. Range 0.25 to 4.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
             <string>F32</string>
             <key>Value</key>
-            <real>0.02</real>
+            <real>1.0</real>
         </map>
-        <key>RenderLensFlareOcclusionTaps</key>
+        <key>RenderLensFlareFadeTime</key>
         <map>
             <key>Comment</key>
-            <string>Number of depth samples for sun-occlusion testing. Higher values give smoother partial occlusion transitions at a small performance cost. Range 1 to 32.</string>
+            <string>Seconds for the lens flare to fade in when the sun is revealed; it fades out in 0.6 of this, and never faster whatever passes in front of the sun. Longer is calmer through foliage and fences. Range 0.1 to 1.5.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
-            <string>S32</string>
+            <string>F32</string>
             <key>Value</key>
-            <integer>9</integer>
+            <real>0.35</real>
         </map>
         <key>RenderLensFlareStarburst</key>
         <map>

--- a/indra/newview/app_settings/looks/Golden%20Hour.xml
+++ b/indra/newview/app_settings/looks/Golden%20Hour.xml
@@ -814,7 +814,7 @@
         <key>RenderLensFlareOcclusionScale</key>
         <map>
             <key>Comment</key>
-            <string>Size of the sun-occlusion probe as a multiple of the sun disc; it follows zoom and the sky's sun scale. Below 1 only the core of the disc counts, above 1 objects near the sun start to dim the flare. Range 0.25 to 4.</string>
+            <string>Size of the sun-occlusion probe as a multiple of the sun disc; it follows zoom and the sky's sun scale. Below 1 only the core of the disc counts, above 1 objects near the sun start to dim the flare. Range 0.25 to 2.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
@@ -825,7 +825,7 @@
         <key>RenderLensFlareFadeTime</key>
         <map>
             <key>Comment</key>
-            <string>Seconds for the lens flare to fade in when the sun is revealed; it fades out in 0.6 of this, and never faster whatever passes in front of the sun. Longer is calmer through foliage and fences. Range 0.1 to 1.5.</string>
+            <string>Seconds for the lens flare to fade in when the sun is revealed; it fades out in 0.6 of this, and never faster whatever passes in front of the sun. Longer is calmer through foliage and fences. Range 0.1 to 1.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>

--- a/indra/newview/app_settings/looks/Neutral.xml
+++ b/indra/newview/app_settings/looks/Neutral.xml
@@ -811,27 +811,27 @@
             <key>Value</key>
             <real>0.15</real>
         </map>
-        <key>RenderLensFlareOcclusionRadius</key>
+        <key>RenderLensFlareOcclusionScale</key>
         <map>
             <key>Comment</key>
-            <string>How wide the sun-occlusion test samples the scene depth. Larger values let thin geometry (foliage, wires) dim the flare more gracefully. Range 0.005 to 0.1.</string>
+            <string>Size of the sun-occlusion probe as a multiple of the sun disc; it follows zoom and the sky's sun scale. Below 1 only the core of the disc counts, above 1 objects near the sun start to dim the flare. Range 0.25 to 4.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
             <string>F32</string>
             <key>Value</key>
-            <real>0.02</real>
+            <real>1.0</real>
         </map>
-        <key>RenderLensFlareOcclusionTaps</key>
+        <key>RenderLensFlareFadeTime</key>
         <map>
             <key>Comment</key>
-            <string>Number of depth samples for sun-occlusion testing. Higher values give smoother partial occlusion transitions at a small performance cost. Range 1 to 32.</string>
+            <string>Seconds for the lens flare to fade in when the sun is revealed; it fades out in 0.6 of this, and never faster whatever passes in front of the sun. Longer is calmer through foliage and fences. Range 0.1 to 1.5.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
-            <string>S32</string>
+            <string>F32</string>
             <key>Value</key>
-            <integer>9</integer>
+            <real>0.35</real>
         </map>
         <key>RenderLensFlareStarburst</key>
         <map>

--- a/indra/newview/app_settings/looks/Neutral.xml
+++ b/indra/newview/app_settings/looks/Neutral.xml
@@ -814,7 +814,7 @@
         <key>RenderLensFlareOcclusionScale</key>
         <map>
             <key>Comment</key>
-            <string>Size of the sun-occlusion probe as a multiple of the sun disc; it follows zoom and the sky's sun scale. Below 1 only the core of the disc counts, above 1 objects near the sun start to dim the flare. Range 0.25 to 4.</string>
+            <string>Size of the sun-occlusion probe as a multiple of the sun disc; it follows zoom and the sky's sun scale. Below 1 only the core of the disc counts, above 1 objects near the sun start to dim the flare. Range 0.25 to 2.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
@@ -825,7 +825,7 @@
         <key>RenderLensFlareFadeTime</key>
         <map>
             <key>Comment</key>
-            <string>Seconds for the lens flare to fade in when the sun is revealed; it fades out in 0.6 of this, and never faster whatever passes in front of the sun. Longer is calmer through foliage and fences. Range 0.1 to 1.5.</string>
+            <string>Seconds for the lens flare to fade in when the sun is revealed; it fades out in 0.6 of this, and never faster whatever passes in front of the sun. Longer is calmer through foliage and fences. Range 0.1 to 1.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>

--- a/indra/newview/app_settings/looks/Soft%20Film.xml
+++ b/indra/newview/app_settings/looks/Soft%20Film.xml
@@ -811,27 +811,27 @@
             <key>Value</key>
             <real>0.15</real>
         </map>
-        <key>RenderLensFlareOcclusionRadius</key>
+        <key>RenderLensFlareOcclusionScale</key>
         <map>
             <key>Comment</key>
-            <string>How wide the sun-occlusion test samples the scene depth. Larger values let thin geometry (foliage, wires) dim the flare more gracefully. Range 0.005 to 0.1.</string>
+            <string>Size of the sun-occlusion probe as a multiple of the sun disc; it follows zoom and the sky's sun scale. Below 1 only the core of the disc counts, above 1 objects near the sun start to dim the flare. Range 0.25 to 4.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
             <string>F32</string>
             <key>Value</key>
-            <real>0.02</real>
+            <real>1.0</real>
         </map>
-        <key>RenderLensFlareOcclusionTaps</key>
+        <key>RenderLensFlareFadeTime</key>
         <map>
             <key>Comment</key>
-            <string>Number of depth samples for sun-occlusion testing. Higher values give smoother partial occlusion transitions at a small performance cost. Range 1 to 32.</string>
+            <string>Seconds for the lens flare to fade in when the sun is revealed; it fades out in 0.6 of this, and never faster whatever passes in front of the sun. Longer is calmer through foliage and fences. Range 0.1 to 1.5.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
-            <string>S32</string>
+            <string>F32</string>
             <key>Value</key>
-            <integer>9</integer>
+            <real>0.35</real>
         </map>
         <key>RenderLensFlareStarburst</key>
         <map>

--- a/indra/newview/app_settings/looks/Soft%20Film.xml
+++ b/indra/newview/app_settings/looks/Soft%20Film.xml
@@ -814,7 +814,7 @@
         <key>RenderLensFlareOcclusionScale</key>
         <map>
             <key>Comment</key>
-            <string>Size of the sun-occlusion probe as a multiple of the sun disc; it follows zoom and the sky's sun scale. Below 1 only the core of the disc counts, above 1 objects near the sun start to dim the flare. Range 0.25 to 4.</string>
+            <string>Size of the sun-occlusion probe as a multiple of the sun disc; it follows zoom and the sky's sun scale. Below 1 only the core of the disc counts, above 1 objects near the sun start to dim the flare. Range 0.25 to 2.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
@@ -825,7 +825,7 @@
         <key>RenderLensFlareFadeTime</key>
         <map>
             <key>Comment</key>
-            <string>Seconds for the lens flare to fade in when the sun is revealed; it fades out in 0.6 of this, and never faster whatever passes in front of the sun. Longer is calmer through foliage and fences. Range 0.1 to 1.5.</string>
+            <string>Seconds for the lens flare to fade in when the sun is revealed; it fades out in 0.6 of this, and never faster whatever passes in front of the sun. Longer is calmer through foliage and fences. Range 0.1 to 1.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>

--- a/indra/newview/app_settings/settings_alchemy.xml
+++ b/indra/newview/app_settings/settings_alchemy.xml
@@ -2592,27 +2592,27 @@
             <key>Value</key>
             <real>0.25</real>
         </map>
-        <key>RenderLensFlareOcclusionRadius</key>
+        <key>RenderLensFlareOcclusionScale</key>
         <map>
             <key>Comment</key>
-            <string>How wide the sun-occlusion test samples the scene depth. Larger values let thin geometry (foliage, wires) dim the flare more gracefully. Range 0.005 to 0.1.</string>
+            <string>Size of the sun-occlusion probe as a multiple of the sun disc; it follows zoom and the sky's sun scale. Below 1 only the core of the disc counts, above 1 objects near the sun start to dim the flare. Range 0.25 to 4.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
             <string>F32</string>
             <key>Value</key>
-            <real>0.02</real>
+            <real>1.0</real>
         </map>
-        <key>RenderLensFlareOcclusionTaps</key>
+        <key>RenderLensFlareFadeTime</key>
         <map>
             <key>Comment</key>
-            <string>Number of depth samples for sun-occlusion testing. Higher values give smoother partial occlusion transitions at a small performance cost. Range 1 to 32.</string>
+            <string>Seconds for the lens flare to fade in when the sun is revealed; it fades out in 0.6 of this, and never faster whatever passes in front of the sun. Longer is calmer through foliage and fences. Range 0.1 to 1.5.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
-            <string>S32</string>
+            <string>F32</string>
             <key>Value</key>
-            <integer>9</integer>
+            <real>0.35</real>
         </map>
         <key>RenderParcelSelectionToMaxHeight</key>
         <map>

--- a/indra/newview/app_settings/settings_alchemy.xml
+++ b/indra/newview/app_settings/settings_alchemy.xml
@@ -2595,7 +2595,7 @@
         <key>RenderLensFlareOcclusionScale</key>
         <map>
             <key>Comment</key>
-            <string>Size of the sun-occlusion probe as a multiple of the sun disc; it follows zoom and the sky's sun scale. Below 1 only the core of the disc counts, above 1 objects near the sun start to dim the flare. Range 0.25 to 4.</string>
+            <string>Size of the sun-occlusion probe as a multiple of the sun disc; it follows zoom and the sky's sun scale. Below 1 only the core of the disc counts, above 1 objects near the sun start to dim the flare. Range 0.25 to 2.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>
@@ -2606,7 +2606,7 @@
         <key>RenderLensFlareFadeTime</key>
         <map>
             <key>Comment</key>
-            <string>Seconds for the lens flare to fade in when the sun is revealed; it fades out in 0.6 of this, and never faster whatever passes in front of the sun. Longer is calmer through foliage and fences. Range 0.1 to 1.5.</string>
+            <string>Seconds for the lens flare to fade in when the sun is revealed; it fades out in 0.6 of this, and never faster whatever passes in front of the sun. Longer is calmer through foliage and fences. Range 0.1 to 1.</string>
             <key>Persist</key>
             <integer>1</integer>
             <key>Type</key>

--- a/indra/newview/app_settings/shaders/class1/alchemy/colorCorrectF.glsl
+++ b/indra/newview/app_settings/shaders/class1/alchemy/colorCorrectF.glsl
@@ -33,7 +33,6 @@ out vec4 frag_color;
 
 // ---- Input ------------------------------------------------------------------
 uniform sampler2D diffuseRect;
-uniform sampler2D depthMap;
 
 // Shared per-frame sky/water constants, spliced from class1/deferred/environmentBlock.glsl
 // and bound at UB_ENVIRONMENT. Members are read by bare name. Declared unconditionally --

--- a/indra/newview/app_settings/shaders/class1/alchemy/colorCorrectF.glsl
+++ b/indra/newview/app_settings/shaders/class1/alchemy/colorCorrectF.glsl
@@ -80,7 +80,7 @@ vec3 applyChannelCurves(vec3 diff);
 #endif
 
 #ifdef HAS_POST_EFFECTS
-vec3 computeLensFlare(sampler2D diffuse, sampler2D depth, vec2 uv);
+vec3 computeLensFlare(vec2 uv);
 vec4 applyChromaticAberration(sampler2D tex, vec2 uv);
 #endif
 
@@ -110,7 +110,7 @@ void main()
 
 #ifdef HAS_POST_EFFECTS
     vec4 diff = applyChromaticAberration(diffuseRect, vary_fragcoord);
-    diff.rgb += computeLensFlare(diffuseRect, depthMap, vary_fragcoord);
+    diff.rgb += computeLensFlare(vary_fragcoord);
 #else
     vec4 diff = texture(diffuseRect, vary_fragcoord);
 #endif

--- a/indra/newview/app_settings/shaders/class1/alchemy/lensFlareStateF.glsl
+++ b/indra/newview/app_settings/shaders/class1/alchemy/lensFlareStateF.glsl
@@ -1,0 +1,185 @@
+/**
+ * @file lensFlareStateF.glsl
+ * @brief Per-frame lens flare state: how much of the sun is unoccluded, what
+ *        colour it is, and a temporally filtered "drive" the colour-correct
+ *        pass multiplies its flare by. Written to a 2x1 target; read back next
+ *        frame as its own history, exactly like the exposure map.
+ *
+ * Why a separate pass: the occlusion test used to run inside computeLensFlare,
+ * per fragment and from scratch every frame. Its answer is the same for every
+ * pixel on screen, and it was binary in time -- the sun's centre pixel gets
+ * covered, the whole flare (a streak across the frame, halo, ghosts) is gone
+ * in one frame and back the next. A moving camera behind fence posts or
+ * foliage turned that into a strobe. Here the visibility can only change at
+ * a bounded rate, whatever the geometry does.
+ *
+ * Layout (texelFetch, no filtering):
+ *   texel 0: rgb = drive, linear HDR: sun colour x HDR gate x coverage x edge
+ *                  fade, filtered. Premultiplied on purpose -- fading out to
+ *                  black holds the last sun colour for free.
+ *            a   = instability score, sign-packed with the direction of the
+ *                  last significant move of the raw target.
+ *   texel 1: r = raw target luminance, g = reference luminance (a decaying
+ *            running maximum the slew limit is relative to), b = raw coverage,
+ *            a = the dt this frame used. b and a are for inspection only.
+ *
+ * Every constant below was chosen by scripts/content_tools/check_lens_flare_state.py,
+ * which mirrors this file statement for statement. Change them together.
+ *
+ * $LicenseInfo:firstyear=2026&license=viewerlgpl$
+ * Alchemy Viewer Source Code
+ * Copyright (C) 2026, Rye <rye@alchemyviewer.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation;
+ * version 2.1 of the License only.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * $/LicenseInfo$
+ */
+
+/*[EXTRA_CODE_HERE]*/
+
+out vec4 frag_color;
+
+uniform sampler2D diffuseRect;          // linear HDR scene
+uniform sampler2D depthMap;             // final scene depth (after alpha)
+uniform sampler2D uLensFlareStateMap;   // this target, last frame
+
+uniform float dt;                       // frame interval, seconds
+uniform uint  uFrameId;
+uniform vec2  uResolution;              // framebuffer size in pixels
+uniform vec2  uLensFlareSunPos;         // sun (or moon) centre in UV
+uniform float uLensFlareSunVisibility;  // CPU screen-edge fade, 0..1
+uniform float uLensFlareOcclusionRadius;// probe radius as a fraction of screen height
+uniform vec4  uLensFlareFadeParams;     // x tau_in, y tau_out (s); z slew_in, w slew_out (1/s)
+
+const vec3  LUMA         = vec3(0.2126, 0.7152, 0.0722);
+const float GOLDEN_ANGLE = 2.39996322972865332;
+
+// ---- Spatial kernel ---------------------------------------------------------
+// A Fermat spiral of 48 taps: uniform area density with no angular clustering,
+// so a straight edge through the centre reads within 0.02 of half at every
+// angle, and no single tap carries more than 3.3% of the weight. The ad-hoc
+// Poisson table it replaces swung 0.45..0.65 with the edge angle.
+const int   TAP_COUNT = 48;
+const float K_COVER   = 1.0;    // coverage weight  exp(-K_COVER * r^2)
+const float K_COLOR   = 8.0;    // colour weight    exp(-K_COLOR * r^2): tight, so the
+                                // unoccluded mean stays within 2% of the centre texel
+
+// ---- Temporal filter --------------------------------------------------------
+const float DT_MAX      = 0.25; // a stall converges, it does not teleport
+const float TAU_REF     = 2.0;  // reference luminance decay, seconds
+const float STEP_THRESH = 0.1;  // raw-target move that counts as a step, relative to the reference
+const float GAIN        = 0.35; // instability added per direction reversal
+const float TAU_I       = 1.0;  // instability decay, seconds
+const float I_DEADZONE  = 0.30; // one reversal (an ordinary reveal) slows nothing
+const float K_DAMP      = 20.0; // tau multiplier slope above the dead zone
+
+float skyOf(float d)
+{
+    // Only the far layers count as unoccluded: the sun disc is pinned at
+    // 0.999999 and the sky dome at 0.99999 (forward); mirrored under reverse-Z.
+#ifdef REVERSE_Z
+    return smoothstep(0.9999, 1.0, 1.0 - d);
+#else
+    return smoothstep(0.9999, 1.0, d);
+#endif
+}
+
+void main()
+{
+    vec2  sun_uv    = uLensFlareSunPos;
+    vec2  radius_uv = uLensFlareOcclusionRadius * vec2(uResolution.y / max(uResolution.x, 1.0), 1.0);
+    // Rotate the whole pattern by the golden angle each frame: the residual
+    // angular bias becomes zero-mean noise (std 0.017) the filter removes.
+    float rot = float(uFrameId & 1023u) * GOLDEN_ANGLE;
+
+    float w_sum = 0.0;
+    float cover = 0.0;
+    vec3  col   = vec3(0.0);
+    float col_w = 0.0;
+    for (int i = 0; i < TAP_COUNT; i++)
+    {
+        float r  = sqrt((float(i) + 0.5) / float(TAP_COUNT));
+        float a  = float(i) * GOLDEN_ANGLE + rot;
+        vec2  t  = vec2(cos(a), sin(a)) * r;
+        float r2 = dot(t, t);
+        float w  = exp(-K_COVER * r2);
+        vec2  uv = sun_uv + t * radius_uv;
+        w_sum += w;
+        if (any(lessThan(uv, vec2(0.0))) || any(greaterThan(uv, vec2(1.0))))
+        {
+            // Off screen: nothing known, and the edge fade already handles a
+            // sun leaving the frame. Count it as sky, keep it out of the colour.
+            cover += w;
+            continue;
+        }
+        float sky = skyOf(texture(depthMap, uv).r);
+        cover += w * sky;
+        float wc = exp(-K_COLOR * r2) * sky;
+        col   += wc * texture(diffuseRect, uv).rgb;
+        col_w += wc;
+    }
+    cover /= w_sum;
+    col = (col_w > 0.0) ? col / col_w : vec3(0.0);
+
+    // Only an HDR-bright sun drives the flare -- a bright diffuse wall must not.
+    float sun_lum = dot(col, LUMA);
+    float bright  = max(sun_lum - 2.0, 0.0) / max(sun_lum, 1e-4);
+    vec3  target  = col * bright * cover * uLensFlareSunVisibility;
+
+    // ---- Temporal filter, in luminance, RGB following ------------------------
+    vec4  prev0 = texelFetch(uLensFlareStateMap, ivec2(0, 0), 0);
+    vec4  prev1 = texelFetch(uLensFlareStateMap, ivec2(1, 0), 0);
+    float dtc   = clamp(dt, 0.0, DT_MAX);
+    float Lp    = dot(prev0.rgb, LUMA);
+    float Lt    = dot(target, LUMA);
+    float L_ref = max(max(prev1.g * exp(-dtc / TAU_REF), Lt), Lp);
+
+    // Instability: direction reversals of the raw target within about a second.
+    // A fence post train reverses every crossing; a single reveal does not.
+    float packed = prev0.a;
+    float I      = abs(packed);
+    float s_prev = sign(packed);
+    float delta  = (Lt - prev1.r) / max(L_ref, 1e-6);
+    float s_now  = (abs(delta) > STEP_THRESH) ? sign(delta) : 0.0;
+    bool  reversal = (s_now != 0.0) && (s_prev != 0.0) && (s_now != s_prev);
+    I = min(I * exp(-dtc / TAU_I) + (reversal ? GAIN : 0.0), 1.0);
+    float s_store = (s_now != 0.0) ? s_now : s_prev;
+    packed = (s_store != 0.0) ? s_store * max(I, 1e-3) : 0.0;
+
+    // Fade: asymmetric time constants, slowed while unstable, and a slew cap
+    // relative to the reference so no frame moves the drive by more than a
+    // bounded fraction of the sun's recent brightness.
+    bool  rising = Lt > Lp;
+    float tau    = rising ? uLensFlareFadeParams.x : uLensFlareFadeParams.y;
+    tau *= 1.0 + K_DAMP * max(I - I_DEADZONE, 0.0);
+    float alpha  = 1.0 - exp(-dtc / tau);
+    float slew   = rising ? uLensFlareFadeParams.z : uLensFlareFadeParams.w;
+    float cap    = slew * dtc * L_ref;
+    float diff   = abs(Lt - Lp);
+    if (diff > 1e-9)
+    {
+        alpha = min(alpha, cap / diff);
+    }
+    vec3 drive = max(mix(prev0.rgb, target, alpha), vec3(0.0));
+
+    if (gl_FragCoord.x < 1.0)
+    {
+        frag_color = vec4(drive, packed);
+    }
+    else
+    {
+        frag_color = vec4(Lt, L_ref, cover, dtc);
+    }
+}

--- a/indra/newview/app_settings/shaders/class1/alchemy/lensFlareStateF.glsl
+++ b/indra/newview/app_settings/shaders/class1/alchemy/lensFlareStateF.glsl
@@ -151,8 +151,10 @@ void main()
         if (sky > 0.0)
         {
             // Colour fetched only for unoccluded taps, so an occluder texel
-            // never enters the estimate, not even times zero.
-            vec3  c    = texture(diffuseRect, uv).rgb;
+            // never enters the estimate, not even times zero. This fetch sits
+            // in non-uniform control flow, where implicit derivatives are
+            // undefined; an explicit level keeps it defined on every driver.
+            vec3  c    = textureLod(diffuseRect, uv, 0.0).rgb;
             float lum  = dot(c, LUMA);
             vec3  over = c * (max(lum - GATE, 0.0) / max(lum, 1e-4));
             energy += w * sky * over;

--- a/indra/newview/app_settings/shaders/class1/alchemy/lensFlareStateF.glsl
+++ b/indra/newview/app_settings/shaders/class1/alchemy/lensFlareStateF.glsl
@@ -11,20 +11,28 @@
  * covered, the whole flare (a streak across the frame, halo, ghosts) is gone
  * in one frame and back the next. A moving camera behind fence posts or
  * foliage turned that into a strobe. Here the visibility can only change at
- * a bounded rate, whatever the geometry does.
+ * a bounded rate, whatever the geometry does. This header is the one place
+ * that story is told; the other sites point here.
  *
  * Layout (texelFetch, no filtering):
- *   texel 0: rgb = drive, linear HDR: sun colour x HDR gate x coverage x edge
+ *   texel 0: rgb = drive, linear HDR: the sun's overbright colour integrated
+ *                  over the unoccluded part of the disc, times the screen-edge
  *                  fade, filtered. Premultiplied on purpose -- fading out to
- *                  black holds the last sun colour for free.
+ *                  black holds the last sun colour for free, and exact black
+ *                  means no flare whatever the reason.
  *            a   = instability score, sign-packed with the direction of the
- *                  last significant move of the raw target.
+ *                  last registered step of the raw target.
  *   texel 1: r = raw target luminance, g = reference luminance (a decaying
- *            running maximum the slew limit is relative to), b = raw coverage,
- *            a = the dt this frame used. b and a are for inspection only.
+ *            running maximum the slew limit is relative to), b = anchor: the
+ *            raw target luminance at the last registered step -- the step
+ *            detector measures displacement from it, so its verdict does not
+ *            depend on how many frames a crossing takes -- a = the dt this
+ *            frame used, for inspection only.
  *
- * Every constant below was chosen by scripts/content_tools/check_lens_flare_state.py,
- * which mirrors this file statement for statement. Change them together.
+ * This file is the source of truth for the filter. Its mirror,
+ * scripts/content_tools/check_lens_flare_state.py, is the tool that chose the
+ * constants and the only regression test they have: change a constant here
+ * first, then make the script agree and re-run it.
  *
  * $LicenseInfo:firstyear=2026&license=viewerlgpl$
  * Alchemy Viewer Source Code
@@ -56,34 +64,57 @@ uniform sampler2D depthMap;             // final scene depth (after alpha)
 uniform sampler2D uLensFlareStateMap;   // this target, last frame
 
 uniform float dt;                       // frame interval, seconds
-uniform uint  uFrameId;
 uniform vec2  uResolution;              // framebuffer size in pixels
 uniform vec2  uLensFlareSunPos;         // sun (or moon) centre in UV
 uniform float uLensFlareSunVisibility;  // CPU screen-edge fade, 0..1
 uniform float uLensFlareOcclusionRadius;// probe radius as a fraction of screen height
-uniform vec4  uLensFlareFadeParams;     // x tau_in, y tau_out (s); z slew_in, w slew_out (1/s)
+uniform float uLensFlareFadeTime;       // RenderLensFlareFadeTime: seconds for a full fade-in
 
 const vec3  LUMA         = vec3(0.2126, 0.7152, 0.0722);
 const float GOLDEN_ANGLE = 2.39996322972865332;
 
 // ---- Spatial kernel ---------------------------------------------------------
-// A Fermat spiral of 48 taps: uniform area density with no angular clustering,
-// so a straight edge through the centre reads within 0.02 of half at every
-// angle, and no single tap carries more than 3.3% of the weight. The ad-hoc
-// Poisson table it replaces swung 0.45..0.65 with the edge angle.
-const int   TAP_COUNT = 48;
-const float K_COVER   = 1.0;    // coverage weight  exp(-K_COVER * r^2)
-const float K_COLOR   = 8.0;    // colour weight    exp(-K_COLOR * r^2): tight, so the
-                                // unoccluded mean stays within 2% of the centre texel
+// A fixed Fermat spiral of 256 taps, weighted exp(-K_TAP r^2): tight enough that
+// the unoccluded estimate is 98% of the disc's centre texel, dense enough that
+// a straight edge through the centre reads within 0.04 of half at every angle
+// (std 0.015) and no single tap carries more than 3.1% of the weight.
+//
+// The pattern is deliberately NOT rotated per frame. Against a fine occluder
+// such as alpha-masked foliage every tap is a coin toss, and a pattern that
+// moves re-tosses them all every frame: the flare then flickered with the
+// camera and the trees perfectly still. A fixed pattern is exact for a still
+// scene and changes continuously as the camera moves. 48 taps could only
+// afford that with rotation (worst edge bias 0.14, 15% per tap); 256 cannot
+// be told apart from the rotated pattern and cost two fragments a frame.
+//
+// Each tap is gated on its own: an occluded tap contributes nothing, an
+// unoccluded one its overbright colour (only an HDR-bright sun flares, never
+// a bright wall). Gating the mean colour instead switched the whole flare on
+// and off at the threshold whenever the disc was mostly hidden.
+const int   TAP_COUNT = 256;
+const float K_TAP     = 8.0;
+const float GATE      = 2.0;    // luminance below which a texel is not sun
+
+// ---- FadeTime to the filter's rates -----------------------------------------
+// A first-order fade of tau = FadeTime/3 under a slew of 1/FadeTime rises
+// 10-90% in FadeTime; the fall is 0.6x that. The slew is the guarantee: a full
+// off-on-off cycle cannot complete in less than 1.6 FadeTime whatever passes
+// in front of the sun.
+const float TAU_IN_MUL   = 1.0 / 3.0;   // x FadeTime, seconds
+const float TAU_OUT_MUL  = 0.2;         // x FadeTime, seconds
+const float SLEW_IN_MUL  = 1.0;         // / FadeTime, per second, relative to the reference
+const float SLEW_OUT_MUL = 1.0 / 0.6;   // / FadeTime, per second
 
 // ---- Temporal filter --------------------------------------------------------
 const float DT_MAX      = 0.25; // a stall converges, it does not teleport
 const float TAU_REF     = 2.0;  // reference luminance decay, seconds
-const float STEP_THRESH = 0.1;  // raw-target move that counts as a step, relative to the reference
+const float STEP_THRESH = 0.1;  // displacement from the anchor that registers a step,
+                                // relative to the unoccluded sun's brightness
 const float GAIN        = 0.35; // instability added per direction reversal
 const float TAU_I       = 1.0;  // instability decay, seconds
 const float I_DEADZONE  = 0.30; // one reversal (an ordinary reveal) slows nothing
 const float K_DAMP      = 20.0; // tau multiplier slope above the dead zone
+const float SNAP_FLOOR  = 1e-4; // drive luminance below which a black target snaps to exact zero
 
 float skyOf(float d)
 {
@@ -100,72 +131,76 @@ void main()
 {
     vec2  sun_uv    = uLensFlareSunPos;
     vec2  radius_uv = uLensFlareOcclusionRadius * vec2(uResolution.y / max(uResolution.x, 1.0), 1.0);
-    // Rotate the whole pattern by the golden angle each frame: the residual
-    // angular bias becomes zero-mean noise (std 0.017) the filter removes.
-    float rot = float(uFrameId & 1023u) * GOLDEN_ANGLE;
 
     float w_sum = 0.0;
-    float cover = 0.0;
-    vec3  col   = vec3(0.0);
-    float col_w = 0.0;
+    vec3  energy = vec3(0.0);
+    float peak   = 0.0;
     for (int i = 0; i < TAP_COUNT; i++)
     {
         float r  = sqrt((float(i) + 0.5) / float(TAP_COUNT));
-        float a  = float(i) * GOLDEN_ANGLE + rot;
+        float a  = float(i) * GOLDEN_ANGLE;
         vec2  t  = vec2(cos(a), sin(a)) * r;
-        float r2 = dot(t, t);
-        float w  = exp(-K_COVER * r2);
-        vec2  uv = sun_uv + t * radius_uv;
+        float w  = exp(-K_TAP * dot(t, t));
         w_sum += w;
-        if (any(lessThan(uv, vec2(0.0))) || any(greaterThan(uv, vec2(1.0))))
-        {
-            // Off screen: nothing known, and the edge fade already handles a
-            // sun leaving the frame. Count it as sky, keep it out of the colour.
-            cover += w;
-            continue;
-        }
+        // A tap past the frame reads the nearest edge texel for depth and
+        // colour, as the clamped sampler did before this pass existed: an
+        // occluder reaching the edge still occludes, and a sun just out of
+        // view keeps its glow, so the streak survives across the edge margin.
+        vec2  uv  = clamp(sun_uv + t * radius_uv, vec2(0.0), vec2(1.0));
         float sky = skyOf(texture(depthMap, uv).r);
-        cover += w * sky;
-        float wc = exp(-K_COLOR * r2) * sky;
-        col   += wc * texture(diffuseRect, uv).rgb;
-        col_w += wc;
+        if (sky > 0.0)
+        {
+            // Colour fetched only for unoccluded taps, so an occluder texel
+            // never enters the estimate, not even times zero.
+            vec3  c    = texture(diffuseRect, uv).rgb;
+            float lum  = dot(c, LUMA);
+            vec3  over = c * (max(lum - GATE, 0.0) / max(lum, 1e-4));
+            energy += w * sky * over;
+            peak    = max(peak, dot(over, LUMA));
+        }
     }
-    cover /= w_sum;
-    col = (col_w > 0.0) ? col / col_w : vec3(0.0);
-
-    // Only an HDR-bright sun drives the flare -- a bright diffuse wall must not.
-    float sun_lum = dot(col, LUMA);
-    float bright  = max(sun_lum - 2.0, 0.0) / max(sun_lum, 1e-4);
-    vec3  target  = col * bright * cover * uLensFlareSunVisibility;
+    vec3 sun_drive = energy / w_sum;                // the visible sun's overbright colour
+    vec3 target    = sun_drive * uLensFlareSunVisibility;
 
     // ---- Temporal filter, in luminance, RGB following ------------------------
-    vec4  prev0 = texelFetch(uLensFlareStateMap, ivec2(0, 0), 0);
-    vec4  prev1 = texelFetch(uLensFlareStateMap, ivec2(1, 0), 0);
-    float dtc   = clamp(dt, 0.0, DT_MAX);
-    float Lp    = dot(prev0.rgb, LUMA);
-    float Lt    = dot(target, LUMA);
-    float L_ref = max(max(prev1.g * exp(-dtc / TAU_REF), Lt), Lp);
+    vec4  prev0  = texelFetch(uLensFlareStateMap, ivec2(0, 0), 0);
+    vec4  prev1  = texelFetch(uLensFlareStateMap, ivec2(1, 0), 0);
+    float dtc    = clamp(dt, 0.0, DT_MAX);
+    float fade   = max(uLensFlareFadeTime, 0.05);
+    float Lp     = dot(prev0.rgb, LUMA);
+    float Lt     = dot(target, LUMA);
+    float L_full = peak;                            // the sun as if fully unoccluded
+    float L_ref  = max(max(prev1.g * exp(-dtc / TAU_REF), Lt), Lp);
 
     // Instability: direction reversals of the raw target within about a second.
-    // A fence post train reverses every crossing; a single reveal does not.
-    float packed = prev0.a;
-    float I      = abs(packed);
-    float s_prev = sign(packed);
-    float delta  = (Lt - prev1.r) / max(L_ref, 1e-6);
+    // A step is a move of more than STEP_THRESH away from the anchor (the value
+    // at the last step), measured against the unoccluded sun's brightness
+    // rather than the current level, so neither a crossing spread over many
+    // frames nor the tap jitter behind a thin post can hide or fake one. A
+    // fence post train reverses every crossing; a single reveal does not.
+    float inst_packed = prev0.a;
+    float I      = abs(inst_packed);
+    float s_prev = sign(inst_packed);
+    float anchor = prev1.b;
+    float delta  = (Lt - anchor) / max(max(L_full, L_ref), 1e-6);
     float s_now  = (abs(delta) > STEP_THRESH) ? sign(delta) : 0.0;
+    if (s_now != 0.0)
+    {
+        anchor = Lt;
+    }
     bool  reversal = (s_now != 0.0) && (s_prev != 0.0) && (s_now != s_prev);
     I = min(I * exp(-dtc / TAU_I) + (reversal ? GAIN : 0.0), 1.0);
     float s_store = (s_now != 0.0) ? s_now : s_prev;
-    packed = (s_store != 0.0) ? s_store * max(I, 1e-3) : 0.0;
+    inst_packed = (s_store != 0.0) ? s_store * max(I, 1e-3) : 0.0;
 
-    // Fade: asymmetric time constants, slowed while unstable, and a slew cap
-    // relative to the reference so no frame moves the drive by more than a
-    // bounded fraction of the sun's recent brightness.
+    // Fade: asymmetric time constants from FadeTime, slowed while unstable,
+    // and a slew cap relative to the reference so no frame moves the drive by
+    // more than a bounded fraction of the sun's recent brightness.
     bool  rising = Lt > Lp;
-    float tau    = rising ? uLensFlareFadeParams.x : uLensFlareFadeParams.y;
+    float tau    = fade * (rising ? TAU_IN_MUL : TAU_OUT_MUL);
     tau *= 1.0 + K_DAMP * max(I - I_DEADZONE, 0.0);
     float alpha  = 1.0 - exp(-dtc / tau);
-    float slew   = rising ? uLensFlareFadeParams.z : uLensFlareFadeParams.w;
+    float slew   = (rising ? SLEW_IN_MUL : SLEW_OUT_MUL) / fade;
     float cap    = slew * dtc * L_ref;
     float diff   = abs(Lt - Lp);
     if (diff > 1e-9)
@@ -173,13 +208,20 @@ void main()
         alpha = min(alpha, cap / diff);
     }
     vec3 drive = max(mix(prev0.rgb, target, alpha), vec3(0.0));
+    // A geometric decay never reaches zero in a half-float target (it pins at
+    // a denormal) and the reader's early-out needs exact black: snap once the
+    // target is black and the drive is far below anything visible.
+    if (Lt <= 0.0 && dot(drive, LUMA) < SNAP_FLOOR)
+    {
+        drive = vec3(0.0);
+    }
 
     if (gl_FragCoord.x < 1.0)
     {
-        frag_color = vec4(drive, packed);
+        frag_color = vec4(drive, inst_packed);
     }
     else
     {
-        frag_color = vec4(Lt, L_ref, cover, dtc);
+        frag_color = vec4(Lt, L_ref, anchor, dtc);
     }
 }

--- a/indra/newview/app_settings/shaders/class1/alchemy/postEffectUtilsF.glsl
+++ b/indra/newview/app_settings/shaders/class1/alchemy/postEffectUtilsF.glsl
@@ -198,13 +198,10 @@ vec4 applyChromaticAberration(sampler2D tex, vec2 uv)
 // Lens flare — anamorphic streak with optional glow, ghosts, halo, starburst
 // =============================================================================
 //
-// Screen-space approximation of an anamorphic lens flare. Driven by a
-// CPU-computed sun UV position and by the sun state texture: how much of the
-// disc is unoccluded, what colour it is and the screen-edge fade are measured
-// once per frame by lensFlareStateF.glsl and filtered over time there, so
-// nothing in this function can pop. It used to probe the depth buffer per
-// fragment -- a frame-wide constant recomputed per pixel, and a one-frame
-// strobe whenever the sun's centre pixel was covered.
+// Screen-space approximation of an anamorphic lens flare, driven by a
+// CPU-computed sun UV position and by the sun state texture that
+// lensFlareStateF.glsl measures and filters once per frame (its header says
+// why the measurement lives there and not here).
 //
 // Each sub-effect (glow / ghosts / halo / starburst) is gated by its own
 // intensity uniform (0 = disabled, else acts as a brightness multiplier), so
@@ -217,9 +214,7 @@ uniform vec2  uLensFlareSunPos;                   // sun position in UV space
 uniform vec3  uLensFlareLightColor;               // artist tint applied to whole flare
 
 // ---- Sun state (2x1, written by lensFlareStateF.glsl each frame) -----------
-// texel 0 rgb = sun colour x HDR gate x unoccluded fraction x edge fade,
-// temporally filtered. Premultiplied: it is the flare's colour and its
-// visibility in one, and black means no flare whatever the reason.
+// texel 0 rgb = the filtered, premultiplied flare drive; black means no flare.
 uniform sampler2D uLensFlareStateMap;
 
 // ---- Anamorphic streak -----------------------------------------------------
@@ -258,10 +253,7 @@ vec3 computeLensFlare(vec2 uv)
     if (uLensFlareStrength <= 0.0)
         return vec3(0.0);
 
-    // The drive: sun colour already multiplied by the HDR gate (only an
-    // overbright sun flares, never a bright wall), by the unoccluded fraction
-    // of the disc and by the screen-edge fade -- and already filtered over
-    // time. Black means no flare, whatever the reason.
+    // The filtered drive from the state pass: colour and visibility in one.
     vec3 sun_color = texelFetch(uLensFlareStateMap, ivec2(0, 0), 0).rgb;
     if (max(sun_color.r, max(sun_color.g, sun_color.b)) <= 0.0)
         return vec3(0.0);
@@ -391,7 +383,7 @@ vec3 computeLensFlare(vec2 uv)
     }
 
     // Final scale: 0.15 tames peak intensity to a plausible lens-response
-    // range; tint and visibility factor apply equally to all sub-effects.
+    // range; tint and the master strength apply equally to all sub-effects.
     return max(flare * vis * uLensFlareLightColor * 0.15, vec3(0.0));
 }
 

--- a/indra/newview/app_settings/shaders/class1/alchemy/postEffectUtilsF.glsl
+++ b/indra/newview/app_settings/shaders/class1/alchemy/postEffectUtilsF.glsl
@@ -15,7 +15,7 @@
  *
  *   LINEAR SPACE (colorCorrectF)
  *     vec4 applyChromaticAberration(sampler2D tex, vec2 uv)
- *     vec3 computeLensFlare       (sampler2D diff, sampler2D depth, vec2 uv)
+ *     vec3 computeLensFlare       (vec2 uv)
  *
  *   DISPLAY SPACE (blitWithEffectsF)
  *     vec3 applyVignette          (vec3 color, vec2 uv)
@@ -199,9 +199,12 @@ vec4 applyChromaticAberration(sampler2D tex, vec2 uv)
 // =============================================================================
 //
 // Screen-space approximation of an anamorphic lens flare. Driven by a
-// CPU-computed sun UV position and visibility (on-screen fade), plus a
-// multi-tap depth occlusion check done here so geometry in front of the sun
-// attenuates the flare smoothly.
+// CPU-computed sun UV position and by the sun state texture: how much of the
+// disc is unoccluded, what colour it is and the screen-edge fade are measured
+// once per frame by lensFlareStateF.glsl and filtered over time there, so
+// nothing in this function can pop. It used to probe the depth buffer per
+// fragment -- a frame-wide constant recomputed per pixel, and a one-frame
+// strobe whenever the sun's centre pixel was covered.
 //
 // Each sub-effect (glow / ghosts / halo / starburst) is gated by its own
 // intensity uniform (0 = disabled, else acts as a brightness multiplier), so
@@ -211,12 +214,13 @@ vec4 applyChromaticAberration(sampler2D tex, vec2 uv)
 // ---- Driver inputs (set by the viewer each frame) --------------------------
 uniform float uLensFlareStrength;                 // master on/off + intensity
 uniform vec2  uLensFlareSunPos;                   // sun position in UV space
-uniform float uLensFlareSunVisibility;            // CPU-side on-screen fade
 uniform vec3  uLensFlareLightColor;               // artist tint applied to whole flare
 
-// ---- Depth occlusion -------------------------------------------------------
-uniform float uLensFlareOcclusionRadius;          // Poisson disk radius in UV space
-uniform int   uLensFlareOcclusionTaps;            // 1..32 — more taps = smoother partial occlusion
+// ---- Sun state (2x1, written by lensFlareStateF.glsl each frame) -----------
+// texel 0 rgb = sun colour x HDR gate x unoccluded fraction x edge fade,
+// temporally filtered. Premultiplied: it is the flare's colour and its
+// visibility in one, and black means no flare whatever the reason.
+uniform sampler2D uLensFlareStateMap;
 
 // ---- Anamorphic streak -----------------------------------------------------
 uniform float uLensFlareStreakLength;             // horizontal extent in UV space
@@ -248,92 +252,22 @@ uniform int   uLensFlareStarburstSpikes;          // primary angular frequency �
 uniform float uLensFlareStarburstSharpness;       // pow() exponent — higher = tighter spikes
 uniform float uLensFlareStarburstFalloff;         // radial decay rate from the sun
 
-vec3 computeLensFlare(sampler2D diffuse, sampler2D depth, vec2 uv)
+vec3 computeLensFlare(vec2 uv)
 {
     // Master gate: cheapest possible early-out.
-    float vis = uLensFlareSunVisibility * uLensFlareStrength;
-    if (vis <= 0.0)
+    if (uLensFlareStrength <= 0.0)
         return vec3(0.0);
 
-    vec2 sun_uv = uLensFlareSunPos;
-
-    // -------------------------------------------------------------------
-    // Depth-based occlusion.
-    //
-    // CPU-side visibility only tracks whether the sun is on-screen; it
-    // doesn't know about intervening geometry. Probe a Poisson disk of
-    // depth taps around the sun's UV and count how many are at the far
-    // plane (i.e. sky). This gives smooth partial occlusion when the sun
-    // is half-behind an object.
-    // -------------------------------------------------------------------
-    if (all(greaterThanEqual(sun_uv, vec2(0.0))) && all(lessThanEqual(sun_uv, vec2(1.0))))
-    {
-        // Pre-baked Poisson disk samples, good spatial distribution.
-        const vec2 taps[32] = vec2[32](
-            vec2( 0.0,     0.0),
-            vec2(-0.326,  -0.406),
-            vec2(-0.840,  -0.074),
-            vec2(-0.196,   0.457),
-            vec2( 0.498,   0.336),
-            vec2( 0.106,  -0.747),
-            vec2( 0.736,  -0.290),
-            vec2( 0.423,   0.767),
-            vec2(-0.621,   0.572),
-            vec2( 0.890,   0.156),
-            vec2(-0.453,  -0.780),
-            vec2( 0.215,  -0.945),
-            vec2(-0.928,   0.326),
-            vec2( 0.673,  -0.685),
-            vec2(-0.158,   0.892),
-            vec2( 0.952,   0.548),
-            vec2(-0.756,  -0.518),
-            vec2( 0.347,  -0.412),
-            vec2(-0.089,  -0.290),
-            vec2( 0.612,   0.710),
-            vec2(-0.544,   0.815),
-            vec2( 0.818,  -0.543),
-            vec2(-0.987,  -0.321),
-            vec2( 0.145,   0.623),
-            vec2(-0.412,   0.178),
-            vec2( 0.567,  -0.098),
-            vec2(-0.278,  -0.654),
-            vec2( 0.934,   0.389),
-            vec2(-0.703,   0.112),
-            vec2( 0.056,  -0.512),
-            vec2( 0.289,   0.934),
-            vec2(-0.867,   0.745)
-        );
-        int   num_taps = clamp(uLensFlareOcclusionTaps, 1, 32);
-        float occluded = 0.0;
-        for (int i = 0; i < num_taps; i++)
-        {
-            vec2  tap_uv = sun_uv + taps[i] * uLensFlareOcclusionRadius;
-            float d      = texture(depth, tap_uv).r;
-            // smoothstep against near-far plane — only sky counts as visible. Mirror the far
-            // end under reverse-Z (far=0): smoothstep(0.9999,1,1-d) == 1-smoothstep(0,1e-4,d).
-#ifdef REVERSE_Z
-            occluded += smoothstep(0.9999, 1.0, 1.0 - d);
-#else
-            occluded += smoothstep(0.9999, 1.0, d);
-#endif
-        }
-        vis *= occluded / float(num_taps);
-    }
-    if (vis <= 0.0)
+    // The drive: sun colour already multiplied by the HDR gate (only an
+    // overbright sun flares, never a bright wall), by the unoccluded fraction
+    // of the disc and by the screen-edge fade -- and already filtered over
+    // time. Black means no flare, whatever the reason.
+    vec3 sun_color = texelFetch(uLensFlareStateMap, ivec2(0, 0), 0).rgb;
+    if (max(sun_color.r, max(sun_color.g, sun_color.b)) <= 0.0)
         return vec3(0.0);
 
-    // -------------------------------------------------------------------
-    // Sample sun brightness once, convert to a normalized "overbright"
-    // factor. We subtract 2.0 from luminance so only HDR-bright suns
-    // drive the flare — prevents diffuse bright surfaces from flaring.
-    // -------------------------------------------------------------------
-    vec3  sun_color  = texture(diffuse, clamp(sun_uv, vec2(0.0), vec2(1.0))).rgb;
-    float sun_lum    = dot(sun_color, LUMA);
-    float sun_bright = max(sun_lum - 2.0, 0.0) / max(sun_lum, 1e-4);
-    sun_color *= sun_bright;
-
-    if (sun_bright <= 0.0)
-        return vec3(0.0);
+    vec2  sun_uv = uLensFlareSunPos;
+    float vis    = uLensFlareStrength;
 
     float aspect = uResolution.x / max(uResolution.y, 1.0);
     vec2  delta  = uv - sun_uv;

--- a/indra/newview/llpresetsmanager.cpp
+++ b/indra/newview/llpresetsmanager.cpp
@@ -597,8 +597,8 @@ void LLPresetsManager::getLooksControlNames(std::vector<std::string>& names)
         "RenderLensFlareStarburstSpikes",
         "RenderLensFlareStarburstSharpness",
         "RenderLensFlareStarburstLength",
-        "RenderLensFlareOcclusionRadius",
-        "RenderLensFlareOcclusionTaps",
+        "RenderLensFlareOcclusionScale",
+        "RenderLensFlareFadeTime",
         // Chromatic aberration
         "RenderChromaticAberrationStrength",
         "RenderChromaticAberrationFalloff",

--- a/indra/newview/llviewershadermgr.cpp
+++ b/indra/newview/llviewershadermgr.cpp
@@ -222,6 +222,7 @@ LLGLSLShader            gDeferredDoFCombineProgram;
 LLGLSLShader            gExposureProgram;
 LLGLSLShader            gExposureProgramNoFade;
 LLGLSLShader            gLuminanceProgram;
+LLGLSLShader            gLensFlareStateProgram;
 LLGLSLShader            gFXAAProgram[4];
 LLGLSLShader            gSMAAEdgeDetectProgram[4];
 LLGLSLShader            gSMAABlendWeightsProgram[4];
@@ -1270,6 +1271,7 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         gExposureProgram.unload();
         gExposureProgramNoFade.unload();
         gLuminanceProgram.unload();
+        gLensFlareStateProgram.unload();
 
         for (auto i = 0; i < 4; ++i)
         {
@@ -2735,6 +2737,20 @@ bool LLViewerShaderMgr::loadShadersDeferred()
         gExposureProgramNoFade.mShaderFiles.push_back(make_pair("deferred/exposureF.glsl", GL_FRAGMENT_SHADER));
         gExposureProgramNoFade.mShaderLevel = mShaderLevel[SHADER_DEFERRED];
         success = gExposureProgramNoFade.createShader();
+        llassert(success);
+    }
+
+    if (success)
+    {
+        // Sun coverage, colour and the filtered flare drive, 2x1, read by the
+        // colour-correct programs through uLensFlareStateMap.
+        gLensFlareStateProgram.mName = "Lens Flare State";
+        gLensFlareStateProgram.mShaderFiles.clear();
+        gLensFlareStateProgram.clearPermutations();
+        gLensFlareStateProgram.mShaderFiles.push_back(make_pair("deferred/postDeferredNoTCV.glsl", GL_VERTEX_SHADER));
+        gLensFlareStateProgram.mShaderFiles.push_back(make_pair("alchemy/lensFlareStateF.glsl", GL_FRAGMENT_SHADER));
+        gLensFlareStateProgram.mShaderLevel = mShaderLevel[SHADER_DEFERRED];
+        success = gLensFlareStateProgram.createShader();
         llassert(success);
     }
 

--- a/indra/newview/llviewershadermgr.h
+++ b/indra/newview/llviewershadermgr.h
@@ -197,6 +197,7 @@ extern LLGLSLShader         gDeferredPostNoDoFProgram;
 extern LLGLSLShader         gExposureProgram;
 extern LLGLSLShader         gExposureProgramNoFade;
 extern LLGLSLShader         gLuminanceProgram;
+extern LLGLSLShader         gLensFlareStateProgram;
 extern LLGLSLShader         gDeferredAvatarShadowProgram;
 extern LLGLSLShader         gDeferredAvatarAlphaShadowProgram;
 extern LLGLSLShader         gDeferredAvatarAlphaMaskShadowProgram;

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -1333,6 +1333,9 @@ void LLPipeline::releaseLUTBuffers()
     mLuminanceMap.release();
     mLastExposure.release();
 
+    mLensFlareState[0].release();
+    mLensFlareState[1].release();
+    mLensFlareStateValid = false;
 }
 
 void LLPipeline::releaseShadowBuffers()
@@ -1589,6 +1592,17 @@ void LLPipeline::createLUTBuffers()
     mLuminanceMap.allocate(256, 256, GL_R16F, false, false, ALTextureSlot::TT_TEXTURE, LLRenderTarget::MIPS_AUTO);
 
     mLastExposure.allocate(1, 1, GL_R16F);
+
+    // Lens flare sun state, 2x1, two of them for ping-pong. Zero is the
+    // correct history: no drive, no instability, no reference luminance.
+    for (LLRenderTarget& state : mLensFlareState)
+    {
+        state.allocate(2, 1, GL_RGBA16F);
+        state.bindTarget();
+        state.clear();
+        state.flush();
+    }
+    mLensFlareStateValid = false;
 }
 
 void LLPipeline::setupGradingLUT()
@@ -7749,6 +7763,126 @@ void LLPipeline::generateExposure(LLRenderTarget* src, LLRenderTarget* dst, bool
     }
 }
 
+// Sun coverage, colour and the temporally filtered flare drive, into a 2x1
+// target the colour-correct programs read through uLensFlareStateMap. This
+// is the only place the flare's visibility changes, and it changes at a
+// bounded rate: see lensFlareStateF.glsl for the filter and
+// scripts/content_tools/check_lens_flare_state.py for the numbers behind it.
+// Runs right before colorCorrect, against the frame's final depth, in both
+// the HDR and non-HDR paths.
+void LLPipeline::generateLensFlareState(LLRenderTarget* src)
+{
+    static LLCachedControl<F32> lens_flare_strength(gSavedSettings, "RenderLensFlareStrength", 0.f);
+    static LLCachedControl<F32> lens_flare_occlusion_scale(gSavedSettings, "RenderLensFlareOcclusionScale", 1.f);
+    static LLCachedControl<F32> lens_flare_fade_time(gSavedSettings, "RenderLensFlareFadeTime", 0.35f);
+
+    const bool active = lens_flare_strength() > 0.f && !gSnapshotNoPost && gLensFlareStateProgram.isComplete();
+    if (!active)
+    {
+        // Leave no history behind: a stale drive would flash back on the
+        // frame the flare is switched on again.
+        if (mLensFlareStateValid)
+        {
+            for (LLRenderTarget& state : mLensFlareState)
+            {
+                state.bindTarget();
+                state.clear();
+                state.flush();
+            }
+            mLensFlareStateValid = false;
+        }
+        return;
+    }
+
+    LL_PROFILE_GPU_ZONE("lens flare state");
+
+    // Sun (or moon) direction to screen UV, with a soft fade over a margin
+    // beyond the frame so the streak survives a sun just out of view.
+    // Gate/divide on clip w, not z: w is convention-independent (reverse-Z
+    // rewrites only the projection's z row), so w > 0 == "sun in front" and
+    // xy/w == ndc under both conventions; z would flip sign under reverse-Z.
+    LLEnvironment& environment = LLEnvironment::instance();
+    const bool sun_up = environment.getIsSunUp();
+    const LLVector4 light_dir = sun_up ? mSunDir : mMoonDir;
+    const glm::vec4 sun_clip = get_current_projection() * get_current_modelview() * glm::vec4(light_dir.mV[0], light_dir.mV[1], light_dir.mV[2], 0.0f);
+    F32 edge_fade = 0.f;
+    if (sun_clip.w > 0.f)
+    {
+        const glm::vec2 sun_uv = glm::vec2(sun_clip.x, sun_clip.y) / sun_clip.w * 0.5f + 0.5f;
+        constexpr F32 margin = 0.2f;
+        edge_fade = llclamp((sun_uv.x + margin) / margin, 0.f, 1.f)
+                  * llclamp(((1.f + margin) - sun_uv.x) / margin, 0.f, 1.f)
+                  * llclamp((sun_uv.y + margin) / margin, 0.f, 1.f)
+                  * llclamp(((1.f + margin) - sun_uv.y) / margin, 0.f, 1.f);
+        mLensFlareSunUV.mV[VX] = sun_uv.x;
+        mLensFlareSunUV.mV[VY] = sun_uv.y;
+    }
+
+    // Probe radius as a fraction of screen height: the body's own angular
+    // radius (updateHeavenlyBodyGeometry: HEAVENLY_BODY_FACTOR x disk radius
+    // x sky scale, at unit distance) through the current vertical FOV, times
+    // the setting. It follows zoom and the sky's sun scale, so an occluder
+    // narrower than the disc dims the flare instead of cutting it.
+    LLSettingsSky::ptr_t psky = environment.getCurrentSky();
+    F32 disk_radius = 0.5f;
+    if (gSky.mVOSkyp.notNull())
+    {
+        disk_radius = (sun_up ? gSky.mVOSkyp->getSun() : gSky.mVOSkyp->getMoon()).getDiskRadius();
+    }
+    const F32 body_scale = llmax(sun_up ? psky->getSunScale() : psky->getMoonScale(), 0.01f);
+    const F32 half_tan   = HEAVENLY_BODY_FACTOR * disk_radius * body_scale;
+    const F32 fov_y      = llclamp(LLViewerCamera::getInstance()->getView(), 0.01f, F_PI - 0.01f);
+    const F32 radius_uv  = 0.5f * half_tan / tanf(fov_y * 0.5f) * llclamp(lens_flare_occlusion_scale(), 0.25f, 4.f);
+
+    // FadeTime to filter constants. A first-order fade of tau = FadeTime/3
+    // under a slew of 1/FadeTime rises 10-90% in FadeTime; the fall is 0.6x
+    // that. The slew is the guarantee: a full off-on-off cycle cannot
+    // complete in less than 1.6 FadeTime whatever passes in front of the sun.
+    const F32 fade     = llclamp(lens_flare_fade_time(), 0.1f, 1.5f);
+    const F32 tau_in   = fade / 3.f;
+    const F32 tau_out  = fade * 0.2f;
+    const F32 slew_in  = 1.f / fade;
+    const F32 slew_out = slew_in / 0.6f;
+
+    // Ping-pong: last frame's state becomes the history this frame reads.
+    mLensFlareState[1].copyContents(mLensFlareState[0], 0, 0, 2, 1, 0, 0, 2, 1, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+    mLensFlareState[0].bindTarget();
+    LLGLDepthTest depth(GL_FALSE, GL_FALSE);
+
+    LLGLSLShader& shader = gLensFlareStateProgram;
+    shader.bind();
+    const S32 diffuse_channel = shader.bindTexture(LLShaderMgr::DEFERRED_DIFFUSE, src, ALSamplers::PointMirror);
+    const S32 depth_channel   = shader.bindDepthTexture(LLShaderMgr::DEFERRED_DEPTH, &mRT->deferredScreen);
+    const S32 state_channel   = shader.bindTexture(LLShaderMgr::LENS_FLARE_STATE_MAP, &mLensFlareState[1], ALSamplers::PointClamp);
+
+    shader.uniform1f(LLShaderMgr::DT, gFrameIntervalSeconds);
+    shader.uniform1ui(LLShaderMgr::FRAME_ID, LLFrameTimer::getFrameCount());
+    shader.uniform2f(LLShaderMgr::SCREEN_RESOLUTION, (GLfloat)src->getWidth(), (GLfloat)src->getHeight());
+    shader.uniform2f(LLShaderMgr::LENS_FLARE_SUN_POS, mLensFlareSunUV.mV[VX], mLensFlareSunUV.mV[VY]);
+    shader.uniform1f(LLShaderMgr::LENS_FLARE_SUN_VISIBILITY, edge_fade);
+    shader.uniform1f(LLShaderMgr::LENS_FLARE_OCCLUSION_RADIUS, radius_uv);
+    shader.uniform4f(LLShaderMgr::LENS_FLARE_FADE_PARAMS, tau_in, tau_out, slew_in, slew_out);
+
+    mScreenTriangleVB->setBuffer();
+    mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
+
+    if (state_channel > -1)
+    {
+        gGL.getTextureSlot(state_channel)->unbind();
+    }
+    if (depth_channel > -1)
+    {
+        gGL.getTextureSlot(depth_channel)->unbind();
+    }
+    if (diffuse_channel > -1)
+    {
+        gGL.getTextureSlot(diffuse_channel)->unbind();
+    }
+    shader.unbind();
+    mLensFlareState[0].flush();
+    mLensFlareStateValid = true;
+}
 
 void LLPipeline::colorCorrect(LLRenderTarget* src, LLRenderTarget* dst, bool apply_tonemap, bool apply_color_grade)
 {
@@ -7812,6 +7946,7 @@ void LLPipeline::colorCorrect(LLRenderTarget* src, LLRenderTarget* dst, bool app
         // the composite no longer needs its own pass. When HDR is off the shader
         // variant lacks the sampler and bindTexture is a no-op via getTextureChannel.
         S32 bloom_channel = -1;
+        S32 state_channel = -1;
         if (mRT->bloomMipCount > 0)
         {
             bloom_channel = shader->bindTexture(LLShaderMgr::BLOOM_SAMPLER, &mRT->bloomMip[0], ALSamplers::BilinearMirror);
@@ -7839,7 +7974,10 @@ void LLPipeline::colorCorrect(LLRenderTarget* src, LLRenderTarget* dst, bool app
         // aberration and the lens flare are applied *inside* this program, in
         // every variant including the no-post ones, so their strengths have to
         // be silenced here or a clean plate still carries both.
-        const bool clean_plate = gSnapshotNoPost;
+        // The material preview sphere comes through here too, with its own
+        // scene buffer; the flare state was measured against the world's
+        // depth, so a preview is a clean plate as far as the flare goes.
+        const bool clean_plate = gSnapshotNoPost || src != &mRT->screen;
 
         // Chromatic aberration parameters
         static LLCachedControl<F32> chromatic_aberration_strength(gSavedSettings, "RenderChromaticAberrationStrength", 0.f);
@@ -7886,51 +8024,20 @@ void LLPipeline::colorCorrect(LLRenderTarget* src, LLRenderTarget* dst, bool app
             static LLCachedControl<S32> lens_flare_starburst_spikes(gSavedSettings, "RenderLensFlareStarburstSpikes", 4);
             static LLCachedControl<F32> lens_flare_starburst_sharpness(gSavedSettings, "RenderLensFlareStarburstSharpness", 24.f);
             static LLCachedControl<F32> lens_flare_starburst_length(gSavedSettings, "RenderLensFlareStarburstLength", 0.25f);
-            static LLCachedControl<F32> lens_flare_occlusion_radius(gSavedSettings, "RenderLensFlareOcclusionRadius", 0.02f);
-            static LLCachedControl<S32> lens_flare_occlusion_taps(gSavedSettings, "RenderLensFlareOcclusionTaps", 9);
 
             // Zeroing the master strength both hits the shader's early-out and
-            // skips the whole detail block below, sun projection included.
+            // skips the whole detail block below.
             F32 strength = clean_plate ? 0.f : llclamp(lens_flare_strength(), 0.f, 1.f);
             shader->uniform1f(LLShaderMgr::LENS_FLARE_STRENGTH, strength);
 
             if (strength > 0.f)
             {
-                // Project sun direction to screen UV
-                LLEnvironment& environment = LLEnvironment::instance();
-                bool sun_up = environment.getIsSunUp();
-                LLVector4 light_dir = sun_up ? mSunDir : mMoonDir;
-
-                glm::vec4 sun_clip = get_current_projection() * get_current_modelview() * glm::vec4(light_dir.mV[0], light_dir.mV[1], light_dir.mV[2], 0.0f);
-
-                F32 target_visibility = 0.f;
-                // Gate/divide on clip w, not z: w is convention-independent (reverse-Z rewrites
-                // only the projection's z row), so w > 0 == "sun in front" and xy/w == ndc under
-                // both forward and reverse-Z. (z would flip sign under reverse-Z and hide the flare.)
-                if (sun_clip.w > 0.f)
-                {
-                    glm::vec2 sun_ndc = glm::vec2(sun_clip.x, sun_clip.y) / sun_clip.w;
-                    glm::vec2 sun_uv = sun_ndc * 0.5f + 0.5f;
-
-                    // Soft fade as sun approaches screen edges — generous margin
-                    // lets the streak persist even when the sun is slightly off-screen.
-                    F32 edge_fade = 1.f;
-                    F32 margin = 0.2f;
-                    edge_fade *= llclamp((sun_uv.x - (-margin)) / margin, 0.f, 1.f);
-                    edge_fade *= llclamp(((1.f + margin) - sun_uv.x) / margin, 0.f, 1.f);
-                    edge_fade *= llclamp((sun_uv.y - (-margin)) / margin, 0.f, 1.f);
-                    edge_fade *= llclamp(((1.f + margin) - sun_uv.y) / margin, 0.f, 1.f);
-
-                    target_visibility = edge_fade;
-                    shader->uniform2f(LLShaderMgr::LENS_FLARE_SUN_POS, sun_uv.x, sun_uv.y);
-                }
-
-                // Temporally smooth visibility to avoid flicker from depth sampling noise.
-                // Fade out faster than fade in for responsive occlusion.
-                F32 fade_speed = (target_visibility < mLensFlareSunVisibility) ? 0.15f : 0.05f;
-                mLensFlareSunVisibility = std::lerp(mLensFlareSunVisibility, target_visibility, fade_speed);
-
-                shader->uniform1f(LLShaderMgr::LENS_FLARE_SUN_VISIBILITY, mLensFlareSunVisibility);
+                // Where the sun is was projected by generateLensFlareState this
+                // frame. Whether it is visible, how much of it, and what colour,
+                // arrive already filtered in the state texture -- this pass no
+                // longer probes depth, and nothing here can pop.
+                shader->uniform2f(LLShaderMgr::LENS_FLARE_SUN_POS, mLensFlareSunUV.mV[VX], mLensFlareSunUV.mV[VY]);
+                state_channel = shader->bindTexture(LLShaderMgr::LENS_FLARE_STATE_MAP, &mLensFlareState[0], ALSamplers::PointClamp);
 
                 // Anamorphic streak
                 shader->uniform1f(LLShaderMgr::LENS_FLARE_STREAK_LENGTH, llclamp(lens_flare_streak_length(), 0.01f, 2.f));
@@ -7965,15 +8072,10 @@ void LLPipeline::colorCorrect(LLRenderTarget* src, LLRenderTarget* dst, bool app
                 F32 starburst_length = llclamp(lens_flare_starburst_length(), 0.f, 1.f);
                 F32 starburst_falloff = 4.f / (starburst_length + 0.05f);
                 shader->uniform1f(LLShaderMgr::LENS_FLARE_STARBURST_FALLOFF, starburst_falloff);
-                shader->uniform1f(LLShaderMgr::LENS_FLARE_OCCLUSION_RADIUS, llclamp(lens_flare_occlusion_radius(), 0.005f, 0.1f));
-                shader->uniform1i(LLShaderMgr::LENS_FLARE_OCCLUSION_TAPS, llclamp(lens_flare_occlusion_taps(), 1, 32));
 
+                const bool sun_up = LLEnvironment::instance().getIsSunUp();
                 LLColor4 light_color = linearColor3(sun_up ? mSunDiffuse : mMoonDiffuse);
                 shader->uniform3f(LLShaderMgr::LENS_FLARE_LIGHT_COLOR, light_color.mV[0], light_color.mV[1], light_color.mV[2]);
-            }
-            else
-            {
-                mLensFlareSunVisibility = 0.f;
             }
         }
 
@@ -8254,6 +8356,10 @@ void LLPipeline::colorCorrect(LLRenderTarget* src, LLRenderTarget* dst, bool app
         if (depth_channel > -1)
         {
             gGL.getTextureSlot(depth_channel)->unbind();
+        }
+        if (state_channel > -1)
+        {
+            gGL.getTextureSlot(state_channel)->unbind();
         }
         gGL.getTextureSlot(diffuse_channel)->unbind();
         shader->unbind();
@@ -9147,6 +9253,10 @@ void LLPipeline::renderFinalize()
         // migration. compositeBloomHDR is preserved for standalone use cases.
         generateBloomHDR(&mRT->screen);
     }
+
+    // Sun coverage, colour and the filtered flare drive, against this frame's
+    // final depth and the linear scene. Both the HDR and non-HDR paths flare.
+    generateLensFlareState(&mRT->screen);
 
     // Read any pending scene probe here, while the buffer still holds linear
     // radiance. One line later it has been white balanced, graded and

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -7832,13 +7832,13 @@ void LLPipeline::generateLensFlareState(LLRenderTarget* src)
     const F32 body_scale = llmax(sun_up ? psky->getSunScale() : psky->getMoonScale(), 0.01f);
     const F32 half_tan   = HEAVENLY_BODY_FACTOR * disk_radius * body_scale;
     const F32 fov_y      = llclamp(LLViewerCamera::getInstance()->getView(), 0.01f, F_PI - 0.01f);
-    const F32 radius_uv  = 0.5f * half_tan / tanf(fov_y * 0.5f) * llclamp(lens_flare_occlusion_scale(), 0.25f, 4.f);
+    const F32 radius_uv  = 0.5f * half_tan / tanf(fov_y * 0.5f) * llclamp(lens_flare_occlusion_scale(), 0.25f, 2.f);
 
     // FadeTime to filter constants. A first-order fade of tau = FadeTime/3
     // under a slew of 1/FadeTime rises 10-90% in FadeTime; the fall is 0.6x
     // that. The slew is the guarantee: a full off-on-off cycle cannot
     // complete in less than 1.6 FadeTime whatever passes in front of the sun.
-    const F32 fade     = llclamp(lens_flare_fade_time(), 0.1f, 1.5f);
+    const F32 fade     = llclamp(lens_flare_fade_time(), 0.1f, 1.f);
     const F32 tau_in   = fade / 3.f;
     const F32 tau_out  = fade * 0.2f;
     const F32 slew_in  = 1.f / fade;

--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -1593,16 +1593,11 @@ void LLPipeline::createLUTBuffers()
 
     mLastExposure.allocate(1, 1, GL_R16F);
 
-    // Lens flare sun state, 2x1, two of them for ping-pong. Zero is the
+    // Lens flare sun state, 2x1, two of them swapped each frame. Zero is the
     // correct history: no drive, no instability, no reference luminance.
-    for (LLRenderTarget& state : mLensFlareState)
-    {
-        state.allocate(2, 1, GL_RGBA16F);
-        state.bindTarget();
-        state.clear();
-        state.flush();
-    }
-    mLensFlareStateValid = false;
+    mLensFlareState[0].allocate(2, 1, GL_RGBA16F);
+    mLensFlareState[1].allocate(2, 1, GL_RGBA16F);
+    clearLensFlareState();
 }
 
 void LLPipeline::setupGradingLUT()
@@ -7763,33 +7758,44 @@ void LLPipeline::generateExposure(LLRenderTarget* src, LLRenderTarget* dst, bool
     }
 }
 
+void LLPipeline::clearLensFlareState()
+{
+    // Only [0] is ever read as history: the swap in generateLensFlareState
+    // makes it last frame's target before anything samples it, and [1] is
+    // fully overwritten by the draw before it is read.
+    mLensFlareState[0].bindTarget();
+    mLensFlareState[0].clear();
+    mLensFlareState[0].flush();
+    mLensFlareStateValid = false;
+}
+
 // Sun coverage, colour and the temporally filtered flare drive, into a 2x1
-// target the colour-correct programs read through uLensFlareStateMap. This
-// is the only place the flare's visibility changes, and it changes at a
-// bounded rate: see lensFlareStateF.glsl for the filter and
-// scripts/content_tools/check_lens_flare_state.py for the numbers behind it.
-// Runs right before colorCorrect, against the frame's final depth, in both
-// the HDR and non-HDR paths.
+// target the colour-correct programs read through uLensFlareStateMap. The
+// only place the flare's visibility changes, at a bounded rate; the filter
+// and the reasons for it are in lensFlareStateF.glsl. Runs right before
+// colorCorrect, against the frame's final depth, in both the HDR and
+// non-HDR paths.
 void LLPipeline::generateLensFlareState(LLRenderTarget* src)
 {
     static LLCachedControl<F32> lens_flare_strength(gSavedSettings, "RenderLensFlareStrength", 0.f);
     static LLCachedControl<F32> lens_flare_occlusion_scale(gSavedSettings, "RenderLensFlareOcclusionScale", 1.f);
     static LLCachedControl<F32> lens_flare_fade_time(gSavedSettings, "RenderLensFlareFadeTime", 0.35f);
 
-    const bool active = lens_flare_strength() > 0.f && !gSnapshotNoPost && gLensFlareStateProgram.isComplete();
-    if (!active)
+    if (gSnapshotNoPost)
     {
-        // Leave no history behind: a stale drive would flash back on the
-        // frame the flare is switched on again.
+        // A clean-plate render: colorCorrect zeroes the strength for this
+        // frame, so hold the history rather than clear it, or the flare would
+        // blink out and fade back in after every no-post snapshot.
+        return;
+    }
+
+    if (lens_flare_strength() <= 0.f || !gLensFlareStateProgram.isComplete())
+    {
+        // Switched off, or nothing to run it with: leave no history behind,
+        // or a stale drive would flash back on the frame the flare returns.
         if (mLensFlareStateValid)
         {
-            for (LLRenderTarget& state : mLensFlareState)
-            {
-                state.bindTarget();
-                state.clear();
-                state.flush();
-            }
-            mLensFlareStateValid = false;
+            clearLensFlareState();
         }
         return;
     }
@@ -7803,6 +7809,17 @@ void LLPipeline::generateLensFlareState(LLRenderTarget* src)
     // xy/w == ndc under both conventions; z would flip sign under reverse-Z.
     LLEnvironment& environment = LLEnvironment::instance();
     const bool sun_up = environment.getIsSunUp();
+    if (sun_up != mLensFlareSunUp)
+    {
+        // The history holds the old body's colour while the anchor moves to
+        // the new one this frame; a sun flare fading out on the moon is wrong,
+        // so start over, as the per-frame probe used to.
+        mLensFlareSunUp = sun_up;
+        if (mLensFlareStateValid)
+        {
+            clearLensFlareState();
+        }
+    }
     const LLVector4 light_dir = sun_up ? mSunDir : mMoonDir;
     const glm::vec4 sun_clip = get_current_projection() * get_current_modelview() * glm::vec4(light_dir.mV[0], light_dir.mV[1], light_dir.mV[2], 0.0f);
     F32 edge_fade = 0.f;
@@ -7830,22 +7847,25 @@ void LLPipeline::generateLensFlareState(LLRenderTarget* src)
         disk_radius = (sun_up ? gSky.mVOSkyp->getSun() : gSky.mVOSkyp->getMoon()).getDiskRadius();
     }
     const F32 body_scale = llmax(sun_up ? psky->getSunScale() : psky->getMoonScale(), 0.01f);
-    const F32 half_tan   = HEAVENLY_BODY_FACTOR * disk_radius * body_scale;
-    const F32 fov_y      = llclamp(LLViewerCamera::getInstance()->getView(), 0.01f, F_PI - 0.01f);
-    const F32 radius_uv  = 0.5f * half_tan / tanf(fov_y * 0.5f) * llclamp(lens_flare_occlusion_scale(), 0.25f, 2.f);
+    // The drawn quad grows towards the horizon (1.3x wide and 1.2x tall at
+    // dir.z = 0, llvosky.cpp); a circular probe takes the mean of the two.
+    const F32 enlargement = 1.f + (1.f - light_dir.mV[VZ]) * 0.25f;
+    const F32 half_tan    = HEAVENLY_BODY_FACTOR * disk_radius * body_scale * enlargement;
+    const LLViewerCamera* camera = LLViewerCamera::getInstance();
+    const F32 fov_y       = llclamp(camera->getView(), 0.01f, F_PI - 0.01f);
+    // A tiled snapshot zooms the projection without touching the FOV, and the
+    // radius has to follow the projection the centre was put through. Capped
+    // so a wide sky sun scale at a narrow FOV cannot probe half the frame.
+    const F32 radius_uv   = llmin(0.5f * half_tan / tanf(fov_y * 0.5f) * llmax(camera->getZoomFactor(), 1.f)
+                                  * llclamp(lens_flare_occlusion_scale(), 0.25f, 2.f), 0.3f);
 
-    // FadeTime to filter constants. A first-order fade of tau = FadeTime/3
-    // under a slew of 1/FadeTime rises 10-90% in FadeTime; the fall is 0.6x
-    // that. The slew is the guarantee: a full off-on-off cycle cannot
-    // complete in less than 1.6 FadeTime whatever passes in front of the sun.
-    const F32 fade     = llclamp(lens_flare_fade_time(), 0.1f, 1.f);
-    const F32 tau_in   = fade / 3.f;
-    const F32 tau_out  = fade * 0.2f;
-    const F32 slew_in  = 1.f / fade;
-    const F32 slew_out = slew_in / 0.6f;
+    // The shader derives its time constants and slew from FadeTime itself, so
+    // the filter is defined in one file and its mirror can check it.
+    const F32 fade = llclamp(lens_flare_fade_time(), 0.1f, 1.f);
 
-    // Ping-pong: last frame's state becomes the history this frame reads.
-    mLensFlareState[1].copyContents(mLensFlareState[0], 0, 0, 2, 1, 0, 0, 2, 1, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+    // Ping-pong by swapping handles: [1] becomes last frame's state, the
+    // history this frame reads, and [0] is fully overwritten below.
+    mLensFlareState[0].swapFBORefs(mLensFlareState[1]);
 
     mLensFlareState[0].bindTarget();
     LLGLDepthTest depth(GL_FALSE, GL_FALSE);
@@ -7857,12 +7877,11 @@ void LLPipeline::generateLensFlareState(LLRenderTarget* src)
     const S32 state_channel   = shader.bindTexture(LLShaderMgr::LENS_FLARE_STATE_MAP, &mLensFlareState[1], ALSamplers::PointClamp);
 
     shader.uniform1f(LLShaderMgr::DT, gFrameIntervalSeconds);
-    shader.uniform1ui(LLShaderMgr::FRAME_ID, LLFrameTimer::getFrameCount());
     shader.uniform2f(LLShaderMgr::SCREEN_RESOLUTION, (GLfloat)src->getWidth(), (GLfloat)src->getHeight());
     shader.uniform2f(LLShaderMgr::LENS_FLARE_SUN_POS, mLensFlareSunUV.mV[VX], mLensFlareSunUV.mV[VY]);
     shader.uniform1f(LLShaderMgr::LENS_FLARE_SUN_VISIBILITY, edge_fade);
     shader.uniform1f(LLShaderMgr::LENS_FLARE_OCCLUSION_RADIUS, radius_uv);
-    shader.uniform4f(LLShaderMgr::LENS_FLARE_FADE_PARAMS, tau_in, tau_out, slew_in, slew_out);
+    shader.uniform1f(LLShaderMgr::LENS_FLARE_FADE_TIME, fade);
 
     mScreenTriangleVB->setBuffer();
     mScreenTriangleVB->drawArrays(LLRender::TRIANGLES, 0, 3);
@@ -7938,7 +7957,6 @@ void LLPipeline::colorCorrect(LLRenderTarget* src, LLRenderTarget* dst, bool app
         shader->bind();
 
         S32 diffuse_channel = shader->bindTexture(LLShaderMgr::DEFERRED_DIFFUSE, src, ALSamplers::PointMirror);
-        S32 depth_channel = shader->bindDepthTexture(LLShaderMgr::DEFERRED_DEPTH, &mRT->deferredScreen);
         S32 exposure_channel = shader->bindTexture(LLShaderMgr::EXPOSURE_MAP, &mExposureMap);
 
         // HDR bloom pyramid is folded into the tonemap variants of this shader
@@ -7974,10 +7992,11 @@ void LLPipeline::colorCorrect(LLRenderTarget* src, LLRenderTarget* dst, bool app
         // aberration and the lens flare are applied *inside* this program, in
         // every variant including the no-post ones, so their strengths have to
         // be silenced here or a clean plate still carries both.
-        // The material preview sphere comes through here too, with its own
-        // scene buffer; the flare state was measured against the world's
-        // depth, so a preview is a clean plate as far as the flare goes.
-        const bool clean_plate = gSnapshotNoPost || src != &mRT->screen;
+        const bool clean_plate = gSnapshotNoPost;
+        // The material preview renders through here too, inside the auxiliary
+        // target pack. The flare state was measured for the world frame, so
+        // only the main pack gets the flare; aberration is left as it was.
+        const bool world_frame = (mRT == &mMainRT);
 
         // Chromatic aberration parameters
         static LLCachedControl<F32> chromatic_aberration_strength(gSavedSettings, "RenderChromaticAberrationStrength", 0.f);
@@ -8027,15 +8046,12 @@ void LLPipeline::colorCorrect(LLRenderTarget* src, LLRenderTarget* dst, bool app
 
             // Zeroing the master strength both hits the shader's early-out and
             // skips the whole detail block below.
-            F32 strength = clean_plate ? 0.f : llclamp(lens_flare_strength(), 0.f, 1.f);
+            F32 strength = (clean_plate || !world_frame) ? 0.f : llclamp(lens_flare_strength(), 0.f, 1.f);
             shader->uniform1f(LLShaderMgr::LENS_FLARE_STRENGTH, strength);
 
             if (strength > 0.f)
             {
-                // Where the sun is was projected by generateLensFlareState this
-                // frame. Whether it is visible, how much of it, and what colour,
-                // arrive already filtered in the state texture -- this pass no
-                // longer probes depth, and nothing here can pop.
+                // Sun UV and the filtered drive both come from generateLensFlareState.
                 shader->uniform2f(LLShaderMgr::LENS_FLARE_SUN_POS, mLensFlareSunUV.mV[VX], mLensFlareSunUV.mV[VY]);
                 state_channel = shader->bindTexture(LLShaderMgr::LENS_FLARE_STATE_MAP, &mLensFlareState[0], ALSamplers::PointClamp);
 
@@ -8352,10 +8368,6 @@ void LLPipeline::colorCorrect(LLRenderTarget* src, LLRenderTarget* dst, bool app
         if (bloom_channel > -1)
         {
             gGL.getTextureSlot(bloom_channel)->unbind();
-        }
-        if (depth_channel > -1)
-        {
-            gGL.getTextureSlot(depth_channel)->unbind();
         }
         if (state_channel > -1)
         {
@@ -9254,8 +9266,7 @@ void LLPipeline::renderFinalize()
         generateBloomHDR(&mRT->screen);
     }
 
-    // Sun coverage, colour and the filtered flare drive, against this frame's
-    // final depth and the linear scene. Both the HDR and non-HDR paths flare.
+    // Lens flare sun state (see lensFlareStateF.glsl), in both HDR paths.
     generateLensFlareState(&mRT->screen);
 
     // Read any pending scene probe here, while the buffer still holds linear

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -141,6 +141,7 @@ public:
     void generateLuminance(LLRenderTarget* src, LLRenderTarget* dst);
     void generateExposure(LLRenderTarget* src, LLRenderTarget* dst, bool use_history = true);
     void generateLensFlareState(LLRenderTarget* src);
+    void clearLensFlareState();
     void colorCorrect(LLRenderTarget* src, LLRenderTarget* dst, bool tonemap, bool colorgrade);
     void generateGlow(LLRenderTarget* src);
     void generateBloomHDR(LLRenderTarget* src);
@@ -860,10 +861,11 @@ public:
     LLRenderTarget          mExposureMap;
     LLRenderTarget          mLastExposure;
 
-    // lens flare sun state, 2x1: [0] is current, [1] last frame's copy.
-    // texel 0 = filtered flare drive + instability, texel 1 = raw target + reference
+    // lens flare sun state, 2x1, swapped each frame: [0] is this frame's, [1]
+    // last frame's. Layout in lensFlareStateF.glsl.
     LLRenderTarget          mLensFlareState[2];
     bool                    mLensFlareStateValid = false;
+    bool                    mLensFlareSunUp = true;    // which body the history describes
 
     // FXAA helper target
     LLRenderTarget          mFXAAMap;
@@ -1000,8 +1002,7 @@ public:
     LLVector4           mTransformedSunDir;
     LLVector4           mTransformedMoonDir;
 
-    // Sun (or moon) on screen this frame in UV, projected once by
-    // generateLensFlareState and reused by colorCorrect.
+    // Sun (or moon) on screen this frame in UV, from generateLensFlareState.
     LLVector2           mLensFlareSunUV = LLVector2(0.5f, 0.5f);
 
     bool                    mInitialized;

--- a/indra/newview/pipeline.h
+++ b/indra/newview/pipeline.h
@@ -140,6 +140,7 @@ public:
     void copyScreenSpaceReflections(LLRenderTarget* src, LLRenderTarget* dst);
     void generateLuminance(LLRenderTarget* src, LLRenderTarget* dst);
     void generateExposure(LLRenderTarget* src, LLRenderTarget* dst, bool use_history = true);
+    void generateLensFlareState(LLRenderTarget* src);
     void colorCorrect(LLRenderTarget* src, LLRenderTarget* dst, bool tonemap, bool colorgrade);
     void generateGlow(LLRenderTarget* src);
     void generateBloomHDR(LLRenderTarget* src);
@@ -859,6 +860,11 @@ public:
     LLRenderTarget          mExposureMap;
     LLRenderTarget          mLastExposure;
 
+    // lens flare sun state, 2x1: [0] is current, [1] last frame's copy.
+    // texel 0 = filtered flare drive + instability, texel 1 = raw target + reference
+    LLRenderTarget          mLensFlareState[2];
+    bool                    mLensFlareStateValid = false;
+
     // FXAA helper target
     LLRenderTarget          mFXAAMap;
     LLRenderTarget          mSMAABlendBuffer;
@@ -994,7 +1000,9 @@ public:
     LLVector4           mTransformedSunDir;
     LLVector4           mTransformedMoonDir;
 
-    F32                 mLensFlareSunVisibility = 0.f;
+    // Sun (or moon) on screen this frame in UV, projected once by
+    // generateLensFlareState and reused by colorCorrect.
+    LLVector2           mLensFlareSunUV = LLVector2(0.5f, 0.5f);
 
     bool                    mInitialized;
     bool                    mShadersLoaded;

--- a/indra/newview/skins/default/xui/en/panel_lightbox_lens.xml
+++ b/indra/newview/skins/default/xui/en/panel_lightbox_lens.xml
@@ -2108,17 +2108,16 @@ rebuild. Revisit if RenderBloomHDR gets wired.)
 				 top_pad="8"
 				 right="-32"
 				 height="16"
-				 label="Radius"
+				 label="Size"
 				 label_width="140"
 				 can_edit_text="true"
-				 decimal_digits="3"
-				 text_width="56"
-				 increment="0.001"
-				 min_val="0.005"
-				 max_val="0.1"
-				 name="flare_occlusion_radius"
-				 tool_tip="Width of the sun-occlusion depth test; larger lets thin geometry dim the flare gracefully"
-				 control_name="RenderLensFlareOcclusionRadius" />
+				 decimal_digits="2"
+				 increment="0.05"
+				 min_val="0.25"
+				 max_val="4"
+				 name="flare_occlusion_scale"
+				 tool_tip="Occlusion probe as a multiple of the sun disc; larger lets objects near the sun dim the flare sooner"
+				 control_name="RenderLensFlareOcclusionScale" />
 				<button
 				 follows="top|right"
 				 layout="topleft"
@@ -2129,11 +2128,11 @@ rebuild. Revisit if RenderBloomHDR gets wired.)
 				 scale_image="true"
 				 image_overlay="Refresh_Off"
 				 image_overlay_alignment="center"
-				 name="flare_occlusion_radius_rst"
+				 name="flare_occlusion_scale_rst"
 				 tool_tip="Reset to default">
 					<button.commit_callback
 					 function="LightBox.ResetControlDefault"
-					 parameter="RenderLensFlareOcclusionRadius" />
+					 parameter="RenderLensFlareOcclusionScale" />
 				</button>
 				<slider
 				 follows="left|top|right"
@@ -2142,16 +2141,16 @@ rebuild. Revisit if RenderBloomHDR gets wired.)
 				 top_pad="9"
 				 right="-32"
 				 height="16"
-				 label="Samples"
+				 label="Fade"
 				 label_width="140"
 				 can_edit_text="true"
-				 decimal_digits="0"
-				 increment="1"
-				 min_val="1"
-				 max_val="32"
-				 name="flare_occlusion_taps"
-				 tool_tip="Depth samples for occlusion testing; more gives smoother transitions at slight cost"
-				 control_name="RenderLensFlareOcclusionTaps" />
+				 decimal_digits="2"
+				 increment="0.05"
+				 min_val="0.1"
+				 max_val="1.5"
+				 name="flare_fade_time"
+				 tool_tip="Seconds for the flare to fade in when the sun is revealed; it fades out faster. Longer is calmer through foliage"
+				 control_name="RenderLensFlareFadeTime" />
 				<button
 				 follows="top|right"
 				 layout="topleft"
@@ -2162,11 +2161,11 @@ rebuild. Revisit if RenderBloomHDR gets wired.)
 				 scale_image="true"
 				 image_overlay="Refresh_Off"
 				 image_overlay_alignment="center"
-				 name="flare_occlusion_taps_rst"
+				 name="flare_fade_time_rst"
 				 tool_tip="Reset to default">
 					<button.commit_callback
 					 function="LightBox.ResetControlDefault"
-					 parameter="RenderLensFlareOcclusionTaps" />
+					 parameter="RenderLensFlareFadeTime" />
 				</button>
 				<button
 				 follows="top|right"

--- a/indra/newview/skins/default/xui/en/panel_lightbox_lens.xml
+++ b/indra/newview/skins/default/xui/en/panel_lightbox_lens.xml
@@ -2114,7 +2114,7 @@ rebuild. Revisit if RenderBloomHDR gets wired.)
 				 decimal_digits="2"
 				 increment="0.05"
 				 min_val="0.25"
-				 max_val="4"
+				 max_val="2"
 				 name="flare_occlusion_scale"
 				 tool_tip="Occlusion probe as a multiple of the sun disc; larger lets objects near the sun dim the flare sooner"
 				 control_name="RenderLensFlareOcclusionScale" />
@@ -2147,7 +2147,7 @@ rebuild. Revisit if RenderBloomHDR gets wired.)
 				 decimal_digits="2"
 				 increment="0.05"
 				 min_val="0.1"
-				 max_val="1.5"
+				 max_val="1"
 				 name="flare_fade_time"
 				 tool_tip="Seconds for the flare to fade in when the sun is revealed; it fades out faster. Longer is calmer through foliage"
 				 control_name="RenderLensFlareFadeTime" />

--- a/scripts/content_tools/check_lens_flare_state.py
+++ b/scripts/content_tools/check_lens_flare_state.py
@@ -1,21 +1,32 @@
-"""Offline model of the lens flare state pass (lensFlareStateF.glsl).
+"""Offline mirror of the lens flare state pass, lensFlareStateF.glsl.
 
-Model A -- the spatial coverage kernel: taps on a unit disk with centre-heavy
-weights, driven across edges and poles of various widths.
-Model B -- the temporal filter: fade-in/out time constants, a slew cap
-relative to a running reference luminance, and adaptive damping keyed off
-direction reversals of the raw target.  Replayed at 30/60/144 fps.
+The shader is the source of truth; this script mirrors its kernel and its
+temporal filter statement for statement, is the tool that chose the
+constants, and is the only regression test they have. Change a constant in
+the shader first, then make the copy below agree and re-run this.
 
-Constants chosen here are transcribed into the shader statement for
-statement; keep the two in step.  Pure Python on purpose (no numpy).
+Model A -- the spatial kernel: a fixed Fermat spiral of taps, each gated on
+its own (an occluded tap contributes nothing, an unoccluded one the texel's
+overbright colour), weighted exp(-K_TAP r^2); driven across edges, poles and
+a random needle mask with a still and a drifting camera.
+Model B -- the temporal filter: fade-in/out time constants derived from
+FadeTime, a slew cap relative to a running reference luminance, and adaptive
+damping keyed off direction reversals of the raw target, detected as
+displacement from an anchor so the verdict does not depend on frame rate.
+Replayed at 30/60/144 fps.  Pure Python on purpose (no numpy).
 
     python check_lens_flare_state.py          # verify the chosen constants
-    python check_lens_flare_state.py --grid   # compare tap patterns and weights
+    python check_lens_flare_state.py --grid   # compare tap counts and patterns
 """
 import math
+import random
 import sys
 
 GOLDEN_ANGLE = 2.39996322972865332
+GATE = 2.0           # shader GATE: luminance below which a texel is not sun
+K_TAP = 8.0          # shader K_TAP
+TAP_COUNT = 256      # shader TAP_COUNT
+PX = 46.0            # probe radius in pixels at the default Size, 60 deg FOV, 1080p
 
 # The ad-hoc Poisson disk the original shader used (for comparison only).
 POISSON = [
@@ -36,25 +47,12 @@ def vogel(n):
              math.sqrt((i + 0.5) / n) * math.sin(i * GOLDEN_ANGLE)) for i in range(n)]
 
 
-def rings(spec):
-    """spec = [(radius, count), ...]; a count of 1 is the centre tap."""
-    out = []
-    for ring, (r, n) in enumerate(spec):
-        if n == 1:
-            out.append((0.0, 0.0))
-            continue
-        for i in range(n):
-            a = 2.0 * math.pi * i / n + ring * 0.5   # stagger successive rings
-            out.append((r * math.cos(a), r * math.sin(a)))
-    return out
-
-
 PATTERNS = {
     "poisson32": POISSON,
-    "vogel32": vogel(32),
     "vogel48": vogel(48),
-    "rings1-6-10-15": rings([(0.0, 1), (0.3, 6), (0.6, 10), (0.9, 15)]),
-    "rings1-7-13-19": rings([(0.0, 1), (0.28, 7), (0.58, 13), (0.88, 19)]),
+    "vogel128": vogel(128),
+    "vogel256": vogel(256),
+    "vogel512": vogel(512),
 }
 
 FAIL = []
@@ -74,29 +72,6 @@ def rotate(x, y, a):
 # --------------------------------------------------------------------------
 # Model A: spatial kernel
 # --------------------------------------------------------------------------
-PATTERN = "vogel48"
-K_COVER = 1.0   # coverage weight  w = exp(-K_COVER * r^2)
-K_COLOR = 8.0   # colour weight    w = exp(-K_COLOR * r^2)
-
-
-def kernel(taps, occluded, angle=0.0, lum=None, k_cover=K_COVER, k_color=K_COLOR):
-    """Returns (coverage, mean_lum_of_unoccluded_taps)."""
-    ws = vs = 0.0
-    cs = cw = 0.0
-    for (tx, ty) in taps:
-        x, y = rotate(tx, ty, angle)
-        r2 = x * x + y * y
-        w = math.exp(-k_cover * r2)
-        sky = 0.0 if occluded(x, y) else 1.0
-        ws += w
-        vs += w * sky
-        if lum is not None:
-            wc = math.exp(-k_color * r2) * sky
-            cs += wc * lum(x, y)
-            cw += wc
-    return vs / ws, (cs / cw if cw > 0 else 0.0)
-
-
 def sun_lum(x, y, core=20.0, sky=1.0):
     """Soft disc: bright core to r=0.5, fading to sky at the quad edge r=1."""
     r = math.sqrt(x * x + y * y)
@@ -105,18 +80,33 @@ def sun_lum(x, y, core=20.0, sky=1.0):
     return core + (sky - core) * t
 
 
-def spatial_stats(taps, k_cover):
-    """Numbers that decide between patterns; see model_a for the criteria."""
+def energy(taps, occluded, angle=0.0, k=K_TAP, offset=(0.0, 0.0)):
+    """The shader's estimate: weighted mean over taps of sky_i x overbright_i.
+    `angle` rotates the pattern (equivalently, the edge); `offset` shifts the
+    occluder under the sun (a drifting camera). Returns (drive, peak)."""
+    es = ws = 0.0
+    peak = 0.0
+    for tx, ty in taps:
+        x, y = rotate(tx, ty, angle)
+        w = math.exp(-k * (x * x + y * y))
+        ws += w
+        if not occluded(x + offset[0], y + offset[1]):
+            lum = sun_lum(x, y)
+            over = lum * max(lum - GATE, 0.0) / max(lum, 1e-4)
+            es += w * over
+            peak = max(peak, over)
+    return es / ws, peak
+
+
+def spatial_stats(taps, k=K_TAP):
+    full = energy(taps, lambda x, y: False, k=k)[0]
     angles = [i * GOLDEN_ANGLE for i in range(360)]
-    vals = [kernel(taps, lambda x, y: x < 0.0, a, k_cover=k_cover)[0] for a in angles]
+    vals = [energy(taps, lambda x, y: x < 0.0, a, k)[0] / full for a in angles]
     mean = sum(vals) / len(vals)
     std = math.sqrt(sum((v - mean) ** 2 for v in vals) / len(vals))
-    # consecutive-frame change of a static half occlusion under golden rotation
-    jump = max(abs(a - b) for a, b in zip(vals, vals[1:]))
-    wsum = sum(math.exp(-k_cover * (x * x + y * y)) for x, y in taps)
-    share = max(math.exp(-k_cover * (x * x + y * y)) for x, y in taps) / wsum
-    # largest per-frame step for an edge advancing 0.01 r per frame (fixed pattern)
-    sweep = [kernel(taps, lambda x, y, x0=x0: x < x0, k_cover=k_cover)[0]
+    wsum = sum(math.exp(-k * (x * x + y * y)) for x, y in taps)
+    share = max(math.exp(-k * (x * x + y * y)) for x, y in taps) / wsum
+    sweep = [energy(taps, lambda x, y, x0=x0: x < x0, k=k)[0] / full
              for x0 in [i * 0.01 - 1.2 for i in range(241)]]
     edge_step = max(abs(a - b) for a, b in zip(sweep, sweep[1:]))
     poles = {}
@@ -124,57 +114,119 @@ def spatial_stats(taps, k_cover):
         worst = 1.0
         for i in range(201):
             x0 = i * 0.02 - 2.0
-            c = sum(kernel(taps, lambda x, y, x0=x0, W=W: abs(x - x0) < W * 0.5,
-                           n * GOLDEN_ANGLE, k_cover=k_cover)[0] for n in range(8)) / 8.0
-            worst = min(worst, c)
+            worst = min(worst, energy(taps, lambda x, y, x0=x0, W=W: abs(x - x0) < W * 0.5, k=k)[0] / full)
         poles[W] = worst
-    return dict(mean=mean, std=std, jump=jump, share=share, edge_step=edge_step, poles=poles)
+    return dict(full=full, mean=mean, std=std, worst=max(abs(v - 0.5) for v in vals),
+                share=share, edge_step=edge_step, poles=poles)
+
+
+class NeedleMask:
+    """Random thin segments on a grid: alpha-masked foliage over the sun."""
+    def __init__(self, n_needles, width_px, res=0.02, extent=3.0, seed=7):
+        rng = random.Random(seed)
+        self.res = res
+        self.extent = extent
+        n = int(2 * extent / res)
+        self.n = n
+        grid = bytearray(n * n)
+        w = width_px / PX
+        rr = int(w / 2 / res) + 1
+        for _ in range(n_needles):
+            x0 = rng.uniform(-extent, extent)
+            y0 = rng.uniform(-extent, extent)
+            a = rng.uniform(0, math.pi)
+            L = rng.uniform(0.4, 1.2)
+            dx, dy = math.cos(a), math.sin(a)
+            for s in range(int(L / res) + 1):
+                cx = x0 + dx * s * res
+                cy = y0 + dy * s * res
+                ci = int((cx + extent) / res)
+                cj = int((cy + extent) / res)
+                for i in range(max(ci - rr, 0), min(ci + rr + 1, n)):
+                    for j in range(max(cj - rr, 0), min(cj + rr + 1, n)):
+                        if ((i - ci) * res) ** 2 + ((j - cj) * res) ** 2 <= (w / 2) ** 2:
+                            grid[i * n + j] = 1
+        self.grid = grid
+
+    def occluded(self, x, y):
+        i = int((x + self.extent) / self.res)
+        j = int((y + self.extent) / self.res)
+        if i < 0 or i >= self.n or j < 0 or j >= self.n:
+            return False
+        return self.grid[i * self.n + j] == 1
 
 
 def grid():
-    print("pattern          k   mean   std   jump  share  edge  pole.25 pole.5 pole1  pole2")
+    print("pattern          full   mean   std   worst  share  edge  pole.25 pole.5 pole1  pole2")
     for name, taps in PATTERNS.items():
-        for k in (1.0, 1.5, 2.0):
-            s = spatial_stats(taps, k)
-            print("%-15s %3.1f  %.3f  %.3f  %.3f  %.3f  %.3f  %.3f   %.3f  %.3f  %.3f" % (
-                name, k, s["mean"], s["std"], s["jump"], s["share"], s["edge_step"],
-                s["poles"][0.25], s["poles"][0.5], s["poles"][1.0], s["poles"][2.0]))
+        s = spatial_stats(taps)
+        print("%-15s %5.2f  %.3f  %.3f  %.3f  %.3f  %.3f  %.3f   %.3f  %.3f  %.3f" % (
+            name, s["full"], s["mean"], s["std"], s["worst"], s["share"], s["edge_step"],
+            s["poles"][0.25], s["poles"][0.5], s["poles"][1.0], s["poles"][2.0]))
+
+
+def delta_std(v):
+    d = [b - a for a, b in zip(v, v[1:])]
+    mu = sum(d) / len(d)
+    return math.sqrt(sum((x - mu) ** 2 for x in d) / len(d))
 
 
 def model_a():
-    taps = PATTERNS[PATTERN]
-    print("Model A: spatial kernel (%s, K_COVER=%g, K_COLOR=%g)" % (PATTERN, K_COVER, K_COLOR))
-    s = spatial_stats(taps, K_COVER)
+    taps = vogel(TAP_COUNT)
+    print("Model A: spatial kernel (%d fixed taps, K_TAP=%g, GATE=%g)" % (TAP_COUNT, K_TAP, GATE))
+    s = spatial_stats(taps)
+    check("brightness parity", s["full"] > 0.95 * (20.0 - GATE),
+          "unoccluded drive %.2f vs centre texel overbright %.2f" % (s["full"], 20.0 - GATE))
     check("half-plane mean", abs(s["mean"] - 0.5) < 0.03, "mean %.3f (ideal 0.5)" % s["mean"])
-    check("half-plane bias", s["std"] < 0.03, "std %.3f over edge angles" % s["std"])
-    check("rotation noise", s["jump"] < 0.1,
-          "max frame-to-frame change %.3f under golden rotation (step threshold 0.1)" % s["jump"])
-    check("max tap share", s["share"] < 0.1, "%.3f of weight" % s["share"])
+    check("half-plane bias", s["std"] < 0.03 and s["worst"] < 0.05,
+          "std %.3f, worst %.3f from half over edge angles (the shader header quotes both)" % (
+              s["std"], s["worst"]))
+    check("max tap share", s["share"] < 0.05, "%.3f of weight" % s["share"])
     check("edge step", s["edge_step"] < 0.1, "%.3f per 0.01 r of edge travel" % s["edge_step"])
-    for W, lo, hi in [(0.25, 0.75, 1.0), (0.5, 0.55, 1.0), (1.0, 0.2, 0.75), (2.0, 0.0, 0.05)]:
+    for W, lo, hi in [(0.25, 0.5, 1.0), (0.5, 0.25, 1.0), (1.0, 0.0, 0.05), (2.0, 0.0, 0.01)]:
         check("pole width %.2f" % W, lo <= s["poles"][W] <= hi,
-              "min coverage %.3f (want %.2f..%.2f)" % (s["poles"][W], lo, hi))
-    full = kernel(taps, lambda x, y: False, 0.0, sun_lum)[1]
-    half = kernel(taps, lambda x, y: x < 0.0, 0.0, sun_lum)[1]
-    check("brightness parity", full > 0.95 * 20.0 and half > 0.9 * 20.0,
-          "weighted mean %.2f, half-occluded %.2f, centre texel 20.00" % (full, half))
+              "min drive %.3f (want %.2f..%.2f)" % (s["poles"][W], lo, hi))
+    # Alpha-masked foliage: a still camera must give a constant estimate, and
+    # a drifting one a smooth signal the filter passes without shimmer.
+    mask = NeedleMask(n_needles=150, width_px=2.5)
+    full = s["full"]
+    still = [energy(taps, mask.occluded)[0] / full for _ in range(30)]
+    check("needles, still camera", max(still) - min(still) == 0.0,
+          "coverage %.2f of full, frame-to-frame change %.4f" % (still[0], max(still) - min(still)))
+    for fps, drift_px, limit in ((60, 0.5, 0.01), (30, 1.0, 0.015)):
+        raw = []
+        for i in range(int(2.0 * fps)):
+            off = (drift_px * i / PX, 0.37 * drift_px * i / PX)
+            d, peak = energy(taps, mask.occluded, offset=off)
+            raw.append((d / full, peak / full))
+        st = lit_state()
+        out = []
+        for Lt, L_full in raw:
+            st = step(st, Lt, L_full, 1.0 / fps)
+            out.append(st["drive"])
+        rd = delta_std([r[0] for r in raw])
+        fd = delta_std(out[fps // 2:])
+        check("needles, drifting camera at %d fps" % fps, rd < 0.06 and fd < limit,
+              "raw change %.4f, filtered change %.4f per frame (limit %.3f)" % (rd, fd, limit))
 
 
 # --------------------------------------------------------------------------
-# Model B: temporal filter
+# Model B: temporal filter (mirror of the shader's constants and statements)
 # --------------------------------------------------------------------------
 class P:
-    fade_time = 0.35     # RenderLensFlareFadeTime (seconds)
-    tau_in_mul = 1.0 / 3.0   # tau_in  = fade_time * tau_in_mul
-    tau_out_mul = 0.2        # tau_out = fade_time * tau_out_mul
-    slew_in = 1.0        # x / fade_time: max rise per second, relative to L_ref
-    slew_out = 1.0 / 0.6  # x / fade_time: max fall per second
-    tau_ref = 2.0        # running-max reference decay (s)
-    step_thresh = 0.1    # a raw-target move counts as a step above this (rel. L_ref)
-    gain = 0.35          # instability added per reversal
-    tau_I = 1.0          # instability decay (s)
-    I0 = 0.30            # dead zone: below this, no damping
-    k = 20.0             # tau multiplier slope above the dead zone
+    fade_time = 0.35     # RenderLensFlareFadeTime (seconds); uLensFlareFadeTime
+    tau_in_mul = 1.0 / 3.0   # TAU_IN_MUL
+    tau_out_mul = 0.2        # TAU_OUT_MUL
+    slew_in = 1.0        # SLEW_IN_MUL: / fade_time, per second, relative to L_ref
+    slew_out = 1.0 / 0.6  # SLEW_OUT_MUL
+    dt_max = 0.25        # DT_MAX
+    tau_ref = 2.0        # TAU_REF: running-max reference decay (s)
+    step_thresh = 0.1    # STEP_THRESH: displacement from the anchor, rel. the unoccluded sun
+    gain = 0.35          # GAIN: instability added per reversal
+    tau_I = 1.0          # TAU_I: instability decay (s)
+    I0 = 0.30            # I_DEADZONE
+    k = 20.0             # K_DAMP
+    snap_floor = 1e-4    # SNAP_FLOOR
 
 
 def sign(v):
@@ -182,48 +234,60 @@ def sign(v):
 
 
 def zero_state():
-    return dict(drive=0.0, packed=0.0, prev_raw=0.0, L_ref=0.0)
+    return dict(drive=0.0, packed=0.0, raw=0.0, L_ref=0.0, anchor=0.0)
 
 
 def lit_state():
-    return dict(drive=1.0, packed=0.0, prev_raw=1.0, L_ref=1.0)
+    return dict(drive=1.0, packed=0.0, raw=1.0, L_ref=1.0, anchor=1.0)
 
 
-def step(st, Lt, dt, p=P):
-    """One frame of the state pass, luminance only (RGB follows Lp->Lt)."""
-    dt = min(max(dt, 0.0), 0.25)
+def step(st, Lt, L_full, dt, p=P):
+    """One frame of the state pass, luminance only (RGB follows Lp->Lt).
+    Lt is the raw target (visible overbright sun x edge fade); L_full is the
+    brightest unoccluded tap, the step detector's yardstick."""
+    dt = min(max(dt, 0.0), p.dt_max)
+    fade = max(p.fade_time, 0.05)
     Lp = st["drive"]
     L_ref = max(st["L_ref"] * math.exp(-dt / p.tau_ref), Lt, Lp)
     packed = st["packed"]
     I = abs(packed)
     s_prev = sign(packed)
-    delta = (Lt - st["prev_raw"]) / max(L_ref, 1e-6)
+    anchor = st["anchor"]
+    delta = (Lt - anchor) / max(max(L_full, L_ref), 1e-6)
     s_now = sign(delta) if abs(delta) > p.step_thresh else 0.0
+    if s_now != 0.0:
+        anchor = Lt
     reversal = (s_now != 0.0) and (s_prev != 0.0) and (s_now != s_prev)
-    I = I * math.exp(-dt / p.tau_I) + (p.gain if reversal else 0.0)
-    I = min(I, 1.0)
+    I = min(I * math.exp(-dt / p.tau_I) + (p.gain if reversal else 0.0), 1.0)
     s_store = s_now if s_now != 0.0 else s_prev
     packed = s_store * max(I, 1e-3) if s_store != 0.0 else 0.0
     rising = Lt > Lp
-    tau = p.fade_time * (p.tau_in_mul if rising else p.tau_out_mul)
+    tau = fade * (p.tau_in_mul if rising else p.tau_out_mul)
     tau *= 1.0 + p.k * max(I - p.I0, 0.0)
     alpha = 1.0 - math.exp(-dt / tau)
-    slew = (p.slew_in if rising else p.slew_out) / p.fade_time
+    slew = (p.slew_in if rising else p.slew_out) / fade
     cap = slew * dt * L_ref
     diff = abs(Lt - Lp)
     if diff > 1e-9:
         alpha = min(alpha, cap / diff)
-    drive = Lp + (Lt - Lp) * alpha
-    return dict(drive=drive, packed=packed, prev_raw=Lt, L_ref=L_ref)
+    drive = max(Lp + (Lt - Lp) * alpha, 0.0)
+    if Lt <= 0.0 and drive < p.snap_floor:
+        drive = 0.0
+    return dict(drive=drive, packed=packed, raw=Lt, L_ref=L_ref, anchor=anchor)
 
 
-def run(target_fn, fps, seconds, p=P, start=None):
+def run(target_fn, fps, seconds, p=P, start=None, full_fn=None):
+    """Replay a target sequence. Unless full_fn is given, the sun is taken as
+    fully bright whenever the target is nonzero (partial occlusion of a bright
+    sun) and dark when it is zero (hidden, or behind the camera)."""
     st = start or zero_state()
     dt = 1.0 / fps
     out = []
     for i in range(int(seconds * fps)):
         t = i * dt
-        st = step(st, target_fn(t), dt, p)
+        Lt = target_fn(t)
+        L_full = full_fn(t) if full_fn else (1.0 if Lt > 0.0 else 0.0)
+        st = step(st, Lt, L_full, dt, p)
         out.append((t + dt, st["drive"], abs(st["packed"])))
     return out
 
@@ -237,12 +301,53 @@ def crossing(series, level, rising, after=0.0):
     return None
 
 
+def span(series, hi, lo, rising, after=0.0):
+    """10-90% style interval between two level crossings, or None."""
+    a = crossing(series, lo if rising else hi, rising, after)
+    b = crossing(series, hi if rising else lo, rising, after)
+    return None if a is None or b is None else b - a
+
+
 def window(series, t0, t1):
     return [v for t, v, _ in series if t0 <= t < t1]
 
 
 def square(f):
     return lambda t: 1.0 if int(t * 2 * f) % 2 == 0 else 0.0
+
+
+def ramped_square(f, ramp):
+    """A square wave whose edges are linear ramps of `ramp` seconds: a fence
+    post crossing the probe over several frames rather than one."""
+    period = 1.0 / f
+    half = period / 2.0
+
+    def target(t):
+        u = t % period
+        if u < ramp:
+            return 1.0 - u / ramp
+        if u < half:
+            return 0.0
+        if u < half + ramp:
+            return (u - half) / ramp
+        return 1.0
+    return target
+
+
+def pole_series(W, fps, seconds):
+    """Per-frame drive fraction with a pole of width W disc radii over the
+    sun, jittered by a sub-pixel camera wobble the way a held camera is."""
+    taps = vogel(TAP_COUNT)
+    full = energy(taps, lambda x, y: False)[0]
+    out = []
+    for i in range(int(seconds * fps)):
+        wob = 0.3 / PX * math.sin(i * 0.7)
+        out.append(energy(taps, lambda x, y, W=W: abs(x) < W * 0.5, offset=(wob, 0.0))[0] / full)
+    return out
+
+
+def fmt(v):
+    return "none" if v is None else "%.3fs" % v
 
 
 def model_b(p=P):
@@ -255,19 +360,23 @@ def model_b(p=P):
     ref = None
     for fps in (30, 60, 144):
         s = run(stepfn, fps, 5.0, p)
-        rise = crossing(s, 0.9, True) - crossing(s, 0.1, True)
-        fall = crossing(s, 0.1, False, 3.0) - crossing(s, 0.9, False, 3.0)
+        rise = span(s, 0.9, 0.1, True)
+        fall = span(s, 0.9, 0.1, False, 3.0)
         over = max(v for t, v, _ in s if t < 3.0) - 1.0
         dmax = max(abs(b[1] - a[1]) for a, b in zip(s, s[1:]))
-        print("    %3d fps: rise10-90 %.3fs fall90-10 %.3fs overshoot %.4f max frame delta %.4f" %
-              (fps, rise, fall, over, dmax))
+        print("    %3d fps: rise10-90 %s fall90-10 %s overshoot %.4f max frame delta %.4f" %
+              (fps, fmt(rise), fmt(fall), over, dmax))
         if fps == 60:
-            check("rise time", abs(rise - ft) <= 0.2 * ft, "%.3fs vs fade_time %.2fs" % (rise, ft))
-            check("fall time", abs(fall - 0.6 * ft) <= 0.2 * 0.6 * ft + 0.02,
-                  "%.3fs vs 0.6*fade_time %.3fs" % (fall, 0.6 * ft))
+            check("rise time", rise is not None and abs(rise - ft) <= 0.2 * ft,
+                  "%s vs fade_time %.2fs" % (fmt(rise), ft))
+            check("fall time", fall is not None and abs(fall - 0.6 * ft) <= 0.2 * 0.6 * ft + 0.02,
+                  "%s vs 0.6*fade_time %.3fs" % (fmt(fall), 0.6 * ft))
             check("no overshoot", over <= 1e-6, "%.5f" % over)
             check("frame delta cap", dmax <= p.slew_out / ft / 60.0 + 1e-6,
                   "%.4f per frame at 60 fps" % dmax)
+            check("decays to exact zero", s[-1][1] == 0.0,
+                  "drive %.3e two seconds after the fall (half-float storage pins a "
+                  "geometric decay, hence the snap)" % s[-1][1])
         if ref is None:
             ref = s
         else:
@@ -287,6 +396,19 @@ def model_b(p=P):
         check("%.0f Hz residual" % f, pp <= limit,
               "p-p %.3f in the last second (limit %.2f); first second p-p %.3f, mean %.2f" % (
                   pp, limit, max(first) - min(first), sum(last) / len(last)))
+    # Fence posts crossing the probe over several frames: the damping must
+    # engage whatever the frame rate, and the residual must not depend on it.
+    for ramp in (0.05, 0.1, 0.2):
+        pps = {}
+        for fps in (30, 60, 144):
+            s = run(ramped_square(2.0, ramp), fps, 4.0, p, start=lit_state())
+            last = window(s, 3.0, 4.0)
+            pps[fps] = max(last) - min(last)
+            imax = max(i for t, v, i in s)
+            check("2 Hz, %.2fs edges at %d fps" % (ramp, fps), imax >= p.I0 and pps[fps] <= 0.2,
+                  "instability peak %.2f, residual p-p %.3f" % (imax, pps[fps]))
+        check("2 Hz, %.2fs edges: rate independence" % ramp, max(pps.values()) - min(pps.values()) < 0.05,
+              "p-p spread %.3f across 30/60/144 fps" % (max(pps.values()) - min(pps.values())))
     # Worst-case flash count: full-scale cycles per second the filter can pass.
     cyc = 1.0 / (ft * (1.0 / p.slew_in + 1.0 / p.slew_out))
     check("cycle bound", cyc < 3.0, "at most %.2f full off-on-off cycles per second" % cyc)
@@ -296,15 +418,31 @@ def model_b(p=P):
     check("blip depth", dip < 0.5, "dip %.3f for a 100 ms occlusion" % dip)
     hidden = lambda t: 0.0 if t < 5.0 else 1.0
     s = run(hidden, 60, 8.0, p, start=lit_state())
-    rise = crossing(s, 0.9, True, 5.0) - crossing(s, 0.1, True, 5.0)
-    check("isolated reveal", abs(rise - ft) <= 0.25 * ft, "rise %.3fs vs %.2fs" % (rise, ft))
+    rise = span(s, 0.9, 0.1, True, 5.0)
+    check("isolated reveal", rise is not None and abs(rise - ft) <= 0.25 * ft,
+          "rise %s vs %.2fs" % (fmt(rise), ft))
+    # A thin post held over the sun with a held camera's sub-pixel wobble,
+    # then removed: the wobble must not count as steps, so the reveal is not
+    # slowed.
+    for fps in (30, 60, 144):
+        cov = pole_series(0.6, fps, 5.0)
+        n_hold = len(cov)
+        s = run(lambda t, cov=cov, n_hold=n_hold, fps=fps: cov[int(t * fps)] if int(t * fps) < n_hold else 1.0,
+                fps, 8.0, p, start=lit_state())
+        lo = s[n_hold - 1][1]
+        rise = span(s, lo + 0.9 * (1.0 - lo), lo + 0.1 * (1.0 - lo), True, 5.0)
+        I_at = s[n_hold - 1][2]
+        check("partial occlusion reveal at %d fps" % fps,
+              rise is not None and abs(rise - ft) <= 0.25 * ft and I_at < p.I0,
+              "drive %.2f..%.2f held 5 s, instability %.2f at the reveal, rise %s vs %.2fs" % (
+                  min(cov), max(cov), I_at, fmt(rise), ft))
     mixed = lambda t: square(3.0)(t) if t < 2.0 else 1.0
     s = run(mixed, 60, 6.0, p, start=lit_state())
     t90 = crossing(s, 0.9, True, 2.0)
     check("recovery after strobe", t90 is not None and t90 - 2.0 < 2.5,
           "reaches 0.9 %.2fs after the strobe stops" % ((t90 or 99) - 2.0))
     dim = lambda t: max(1.0 - 0.3 * t, 0.0)
-    s = run(dim, 60, 3.0, p, start=lit_state())
+    s = run(dim, 60, 3.0, p, start=lit_state(), full_fn=dim)
     lag = max(abs(v - dim(t)) for t, v, _ in s)
     check("slow dimming tracks", lag < 0.1, "max lag %.3f" % lag)
     # Noise robustness: a static half occlusion jittered +-0.03 must not

--- a/scripts/content_tools/check_lens_flare_state.py
+++ b/scripts/content_tools/check_lens_flare_state.py
@@ -1,0 +1,327 @@
+"""Offline model of the lens flare state pass (lensFlareStateF.glsl).
+
+Model A -- the spatial coverage kernel: taps on a unit disk with centre-heavy
+weights, driven across edges and poles of various widths.
+Model B -- the temporal filter: fade-in/out time constants, a slew cap
+relative to a running reference luminance, and adaptive damping keyed off
+direction reversals of the raw target.  Replayed at 30/60/144 fps.
+
+Constants chosen here are transcribed into the shader statement for
+statement; keep the two in step.  Pure Python on purpose (no numpy).
+
+    python check_lens_flare_state.py          # verify the chosen constants
+    python check_lens_flare_state.py --grid   # compare tap patterns and weights
+"""
+import math
+import sys
+
+GOLDEN_ANGLE = 2.39996322972865332
+
+# The ad-hoc Poisson disk the original shader used (for comparison only).
+POISSON = [
+    (0.0, 0.0), (-0.326, -0.406), (-0.840, -0.074), (-0.196, 0.457),
+    (0.498, 0.336), (0.106, -0.747), (0.736, -0.290), (0.423, 0.767),
+    (-0.621, 0.572), (0.890, 0.156), (-0.453, -0.780), (0.215, -0.945),
+    (-0.928, 0.326), (0.673, -0.685), (-0.158, 0.892), (0.952, 0.548),
+    (-0.756, -0.518), (0.347, -0.412), (-0.089, -0.290), (0.612, 0.710),
+    (-0.544, 0.815), (0.818, -0.543), (-0.987, -0.321), (0.145, 0.623),
+    (-0.412, 0.178), (0.567, -0.098), (-0.278, -0.654), (0.934, 0.389),
+    (-0.703, 0.112), (0.056, -0.512), (0.289, 0.934), (-0.867, 0.745),
+]
+
+
+def vogel(n):
+    """Fermat spiral: uniform area density, no angular clustering."""
+    return [(math.sqrt((i + 0.5) / n) * math.cos(i * GOLDEN_ANGLE),
+             math.sqrt((i + 0.5) / n) * math.sin(i * GOLDEN_ANGLE)) for i in range(n)]
+
+
+def rings(spec):
+    """spec = [(radius, count), ...]; a count of 1 is the centre tap."""
+    out = []
+    for ring, (r, n) in enumerate(spec):
+        if n == 1:
+            out.append((0.0, 0.0))
+            continue
+        for i in range(n):
+            a = 2.0 * math.pi * i / n + ring * 0.5   # stagger successive rings
+            out.append((r * math.cos(a), r * math.sin(a)))
+    return out
+
+
+PATTERNS = {
+    "poisson32": POISSON,
+    "vogel32": vogel(32),
+    "vogel48": vogel(48),
+    "rings1-6-10-15": rings([(0.0, 1), (0.3, 6), (0.6, 10), (0.9, 15)]),
+    "rings1-7-13-19": rings([(0.0, 1), (0.28, 7), (0.58, 13), (0.88, 19)]),
+}
+
+FAIL = []
+
+
+def check(name, ok, detail):
+    print(("  ok   " if ok else "  FAIL ") + name + ": " + detail)
+    if not ok:
+        FAIL.append(name)
+
+
+def rotate(x, y, a):
+    c, s = math.cos(a), math.sin(a)
+    return (c * x - s * y, s * x + c * y)
+
+
+# --------------------------------------------------------------------------
+# Model A: spatial kernel
+# --------------------------------------------------------------------------
+PATTERN = "vogel48"
+K_COVER = 1.0   # coverage weight  w = exp(-K_COVER * r^2)
+K_COLOR = 8.0   # colour weight    w = exp(-K_COLOR * r^2)
+
+
+def kernel(taps, occluded, angle=0.0, lum=None, k_cover=K_COVER, k_color=K_COLOR):
+    """Returns (coverage, mean_lum_of_unoccluded_taps)."""
+    ws = vs = 0.0
+    cs = cw = 0.0
+    for (tx, ty) in taps:
+        x, y = rotate(tx, ty, angle)
+        r2 = x * x + y * y
+        w = math.exp(-k_cover * r2)
+        sky = 0.0 if occluded(x, y) else 1.0
+        ws += w
+        vs += w * sky
+        if lum is not None:
+            wc = math.exp(-k_color * r2) * sky
+            cs += wc * lum(x, y)
+            cw += wc
+    return vs / ws, (cs / cw if cw > 0 else 0.0)
+
+
+def sun_lum(x, y, core=20.0, sky=1.0):
+    """Soft disc: bright core to r=0.5, fading to sky at the quad edge r=1."""
+    r = math.sqrt(x * x + y * y)
+    t = min(max((r - 0.5) / 0.5, 0.0), 1.0)
+    t = t * t * (3.0 - 2.0 * t)
+    return core + (sky - core) * t
+
+
+def spatial_stats(taps, k_cover):
+    """Numbers that decide between patterns; see model_a for the criteria."""
+    angles = [i * GOLDEN_ANGLE for i in range(360)]
+    vals = [kernel(taps, lambda x, y: x < 0.0, a, k_cover=k_cover)[0] for a in angles]
+    mean = sum(vals) / len(vals)
+    std = math.sqrt(sum((v - mean) ** 2 for v in vals) / len(vals))
+    # consecutive-frame change of a static half occlusion under golden rotation
+    jump = max(abs(a - b) for a, b in zip(vals, vals[1:]))
+    wsum = sum(math.exp(-k_cover * (x * x + y * y)) for x, y in taps)
+    share = max(math.exp(-k_cover * (x * x + y * y)) for x, y in taps) / wsum
+    # largest per-frame step for an edge advancing 0.01 r per frame (fixed pattern)
+    sweep = [kernel(taps, lambda x, y, x0=x0: x < x0, k_cover=k_cover)[0]
+             for x0 in [i * 0.01 - 1.2 for i in range(241)]]
+    edge_step = max(abs(a - b) for a, b in zip(sweep, sweep[1:]))
+    poles = {}
+    for W in (0.25, 0.5, 1.0, 2.0):
+        worst = 1.0
+        for i in range(201):
+            x0 = i * 0.02 - 2.0
+            c = sum(kernel(taps, lambda x, y, x0=x0, W=W: abs(x - x0) < W * 0.5,
+                           n * GOLDEN_ANGLE, k_cover=k_cover)[0] for n in range(8)) / 8.0
+            worst = min(worst, c)
+        poles[W] = worst
+    return dict(mean=mean, std=std, jump=jump, share=share, edge_step=edge_step, poles=poles)
+
+
+def grid():
+    print("pattern          k   mean   std   jump  share  edge  pole.25 pole.5 pole1  pole2")
+    for name, taps in PATTERNS.items():
+        for k in (1.0, 1.5, 2.0):
+            s = spatial_stats(taps, k)
+            print("%-15s %3.1f  %.3f  %.3f  %.3f  %.3f  %.3f  %.3f   %.3f  %.3f  %.3f" % (
+                name, k, s["mean"], s["std"], s["jump"], s["share"], s["edge_step"],
+                s["poles"][0.25], s["poles"][0.5], s["poles"][1.0], s["poles"][2.0]))
+
+
+def model_a():
+    taps = PATTERNS[PATTERN]
+    print("Model A: spatial kernel (%s, K_COVER=%g, K_COLOR=%g)" % (PATTERN, K_COVER, K_COLOR))
+    s = spatial_stats(taps, K_COVER)
+    check("half-plane mean", abs(s["mean"] - 0.5) < 0.03, "mean %.3f (ideal 0.5)" % s["mean"])
+    check("half-plane bias", s["std"] < 0.03, "std %.3f over edge angles" % s["std"])
+    check("rotation noise", s["jump"] < 0.1,
+          "max frame-to-frame change %.3f under golden rotation (step threshold 0.1)" % s["jump"])
+    check("max tap share", s["share"] < 0.1, "%.3f of weight" % s["share"])
+    check("edge step", s["edge_step"] < 0.1, "%.3f per 0.01 r of edge travel" % s["edge_step"])
+    for W, lo, hi in [(0.25, 0.75, 1.0), (0.5, 0.55, 1.0), (1.0, 0.2, 0.75), (2.0, 0.0, 0.05)]:
+        check("pole width %.2f" % W, lo <= s["poles"][W] <= hi,
+              "min coverage %.3f (want %.2f..%.2f)" % (s["poles"][W], lo, hi))
+    full = kernel(taps, lambda x, y: False, 0.0, sun_lum)[1]
+    half = kernel(taps, lambda x, y: x < 0.0, 0.0, sun_lum)[1]
+    check("brightness parity", full > 0.95 * 20.0 and half > 0.9 * 20.0,
+          "weighted mean %.2f, half-occluded %.2f, centre texel 20.00" % (full, half))
+
+
+# --------------------------------------------------------------------------
+# Model B: temporal filter
+# --------------------------------------------------------------------------
+class P:
+    fade_time = 0.35     # RenderLensFlareFadeTime (seconds)
+    tau_in_mul = 1.0 / 3.0   # tau_in  = fade_time * tau_in_mul
+    tau_out_mul = 0.2        # tau_out = fade_time * tau_out_mul
+    slew_in = 1.0        # x / fade_time: max rise per second, relative to L_ref
+    slew_out = 1.0 / 0.6  # x / fade_time: max fall per second
+    tau_ref = 2.0        # running-max reference decay (s)
+    step_thresh = 0.1    # a raw-target move counts as a step above this (rel. L_ref)
+    gain = 0.35          # instability added per reversal
+    tau_I = 1.0          # instability decay (s)
+    I0 = 0.30            # dead zone: below this, no damping
+    k = 20.0             # tau multiplier slope above the dead zone
+
+
+def sign(v):
+    return 1.0 if v > 0 else (-1.0 if v < 0 else 0.0)
+
+
+def zero_state():
+    return dict(drive=0.0, packed=0.0, prev_raw=0.0, L_ref=0.0)
+
+
+def lit_state():
+    return dict(drive=1.0, packed=0.0, prev_raw=1.0, L_ref=1.0)
+
+
+def step(st, Lt, dt, p=P):
+    """One frame of the state pass, luminance only (RGB follows Lp->Lt)."""
+    dt = min(max(dt, 0.0), 0.25)
+    Lp = st["drive"]
+    L_ref = max(st["L_ref"] * math.exp(-dt / p.tau_ref), Lt, Lp)
+    packed = st["packed"]
+    I = abs(packed)
+    s_prev = sign(packed)
+    delta = (Lt - st["prev_raw"]) / max(L_ref, 1e-6)
+    s_now = sign(delta) if abs(delta) > p.step_thresh else 0.0
+    reversal = (s_now != 0.0) and (s_prev != 0.0) and (s_now != s_prev)
+    I = I * math.exp(-dt / p.tau_I) + (p.gain if reversal else 0.0)
+    I = min(I, 1.0)
+    s_store = s_now if s_now != 0.0 else s_prev
+    packed = s_store * max(I, 1e-3) if s_store != 0.0 else 0.0
+    rising = Lt > Lp
+    tau = p.fade_time * (p.tau_in_mul if rising else p.tau_out_mul)
+    tau *= 1.0 + p.k * max(I - p.I0, 0.0)
+    alpha = 1.0 - math.exp(-dt / tau)
+    slew = (p.slew_in if rising else p.slew_out) / p.fade_time
+    cap = slew * dt * L_ref
+    diff = abs(Lt - Lp)
+    if diff > 1e-9:
+        alpha = min(alpha, cap / diff)
+    drive = Lp + (Lt - Lp) * alpha
+    return dict(drive=drive, packed=packed, prev_raw=Lt, L_ref=L_ref)
+
+
+def run(target_fn, fps, seconds, p=P, start=None):
+    st = start or zero_state()
+    dt = 1.0 / fps
+    out = []
+    for i in range(int(seconds * fps)):
+        t = i * dt
+        st = step(st, target_fn(t), dt, p)
+        out.append((t + dt, st["drive"], abs(st["packed"])))
+    return out
+
+
+def crossing(series, level, rising, after=0.0):
+    for t, v, _ in series:
+        if t < after:
+            continue
+        if (v >= level) if rising else (v <= level):
+            return t
+    return None
+
+
+def window(series, t0, t1):
+    return [v for t, v, _ in series if t0 <= t < t1]
+
+
+def square(f):
+    return lambda t: 1.0 if int(t * 2 * f) % 2 == 0 else 0.0
+
+
+def model_b(p=P):
+    ft = p.fade_time
+    print("Model B: temporal filter (fade_time=%.2f tau_in=%.3f tau_out=%.3f slew_in=%.2f/s "
+          "slew_out=%.2f/s gain=%.2f tau_I=%.1f I0=%.2f k=%.0f)" % (
+              ft, ft * p.tau_in_mul, ft * p.tau_out_mul, p.slew_in / ft, p.slew_out / ft,
+              p.gain, p.tau_I, p.I0, p.k))
+    stepfn = lambda t: 1.0 if 0.5 <= t < 3.0 else 0.0
+    ref = None
+    for fps in (30, 60, 144):
+        s = run(stepfn, fps, 5.0, p)
+        rise = crossing(s, 0.9, True) - crossing(s, 0.1, True)
+        fall = crossing(s, 0.1, False, 3.0) - crossing(s, 0.9, False, 3.0)
+        over = max(v for t, v, _ in s if t < 3.0) - 1.0
+        dmax = max(abs(b[1] - a[1]) for a, b in zip(s, s[1:]))
+        print("    %3d fps: rise10-90 %.3fs fall90-10 %.3fs overshoot %.4f max frame delta %.4f" %
+              (fps, rise, fall, over, dmax))
+        if fps == 60:
+            check("rise time", abs(rise - ft) <= 0.2 * ft, "%.3fs vs fade_time %.2fs" % (rise, ft))
+            check("fall time", abs(fall - 0.6 * ft) <= 0.2 * 0.6 * ft + 0.02,
+                  "%.3fs vs 0.6*fade_time %.3fs" % (fall, 0.6 * ft))
+            check("no overshoot", over <= 1e-6, "%.5f" % over)
+            check("frame delta cap", dmax <= p.slew_out / ft / 60.0 + 1e-6,
+                  "%.4f per frame at 60 fps" % dmax)
+        if ref is None:
+            ref = s
+        else:
+            coarse, fine = (ref, s) if len(ref) < len(s) else (s, ref)
+            worst = 0.0
+            for t, v, _ in coarse:
+                j = min(range(len(fine)), key=lambda k: abs(fine[k][0] - t))
+                worst = max(worst, abs(fine[j][1] - v))
+            check("frame-rate independence %d fps" % fps, worst < 0.03,
+                  "max deviation %.3f vs 30 fps" % worst)
+    # Square waves from a lit state: residual swing over the last second of four.
+    for f, limit in ((1.0, 0.5), (2.0, 0.2), (3.0, 0.15), (5.0, 0.15), (8.0, 0.15)):
+        s = run(square(f), 60, 4.0, p, start=lit_state())
+        last = window(s, 3.0, 4.0)
+        first = window(s, 0.0, 1.0)
+        pp = max(last) - min(last)
+        check("%.0f Hz residual" % f, pp <= limit,
+              "p-p %.3f in the last second (limit %.2f); first second p-p %.3f, mean %.2f" % (
+                  pp, limit, max(first) - min(first), sum(last) / len(last)))
+    # Worst-case flash count: full-scale cycles per second the filter can pass.
+    cyc = 1.0 / (ft * (1.0 / p.slew_in + 1.0 / p.slew_out))
+    check("cycle bound", cyc < 3.0, "at most %.2f full off-on-off cycles per second" % cyc)
+    blip = lambda t: 0.0 if 1.0 <= t < 1.1 else 1.0
+    s = run(blip, 60, 3.0, p, start=lit_state())
+    dip = 1.0 - min(v for t, v, _ in s)
+    check("blip depth", dip < 0.5, "dip %.3f for a 100 ms occlusion" % dip)
+    hidden = lambda t: 0.0 if t < 5.0 else 1.0
+    s = run(hidden, 60, 8.0, p, start=lit_state())
+    rise = crossing(s, 0.9, True, 5.0) - crossing(s, 0.1, True, 5.0)
+    check("isolated reveal", abs(rise - ft) <= 0.25 * ft, "rise %.3fs vs %.2fs" % (rise, ft))
+    mixed = lambda t: square(3.0)(t) if t < 2.0 else 1.0
+    s = run(mixed, 60, 6.0, p, start=lit_state())
+    t90 = crossing(s, 0.9, True, 2.0)
+    check("recovery after strobe", t90 is not None and t90 - 2.0 < 2.5,
+          "reaches 0.9 %.2fs after the strobe stops" % ((t90 or 99) - 2.0))
+    dim = lambda t: max(1.0 - 0.3 * t, 0.0)
+    s = run(dim, 60, 3.0, p, start=lit_state())
+    lag = max(abs(v - dim(t)) for t, v, _ in s)
+    check("slow dimming tracks", lag < 0.1, "max lag %.3f" % lag)
+    # Noise robustness: a static half occlusion jittered +-0.03 must not
+    # trigger the reversal detector or wobble the drive.
+    noisy = lambda t: 0.5 + 0.03 * math.sin(t * 97.0) * math.cos(t * 31.0)
+    s = run(noisy, 60, 4.0, p, start=lit_state())
+    last = window(s, 3.0, 4.0)
+    imax = max(i for t, v, i in s)
+    check("noise immunity", max(last) - min(last) < 0.02 and imax < p.I0,
+          "drive p-p %.4f, instability peak %.3f" % (max(last) - min(last), imax))
+
+
+if __name__ == "__main__":
+    if "--grid" in sys.argv:
+        grid()
+        sys.exit(0)
+    model_a()
+    model_b()
+    print("%d failure(s)" % len(FAIL))
+    sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
## Problem

The sun lens flare strobed whenever a moving camera alternately hid and revealed the sun:
fence posts, foliage, orbiting an avatar with the sun behind it. Every element of the flare
(a streak across the full frame width, halo, ghosts, starburst, glow) went out in one frame
and came back in the next. At that size and rate it is a photosensitivity hazard.

`computeLensFlare` decided visibility per fragment, from scratch, every frame: nine
effectively binary depth taps in a 0.02 UV disk, plus one point-sampled sun texel with a
hard return when it was not HDR-bright. Covering the sun's centre pixel switched the whole
flare off. The CPU lerp that looked like smoothing only touched the screen-edge fade, at a
per-frame rate.

## What this does

**A per-frame state pass.** `LLPipeline::generateLensFlareState()` runs right before
`colorCorrect` (both HDR paths) and draws the new `class1/alchemy/lensFlareStateF.glsl` into
a 2x1 RGBA16F target pair, ping-ponged by handle swap like the exposure map. Texel 0 holds a
filtered, premultiplied flare drive (sun colour x HDR gate x unoccluded fraction x edge
fade) plus an instability score; texel 1 holds the raw target, a decaying reference
luminance and the step detector's anchor. `computeLensFlare(vec2 uv)` reads one texel and no
longer touches depth or the scene buffer, which also removes ten texture reads per fragment
for a frame-wide constant.

**The probe.** 256 fixed taps on a Fermat spiral around the sun, weighted `exp(-8 r^2)`,
each gated on its own: an occluded tap contributes nothing, an unoccluded one its overbright
colour. The radius is the sun disc's own angular radius through the current FOV (with the
horizon enlargement the drawn quad gets, and the snapshot zoom), scaled by a setting. A
still scene gives an identical estimate every frame; an occluder narrower than the disc dims
the flare instead of cutting it.

**The filter.** In luminance with RGB following: fade-in `tau = FadeTime/3`, fade-out 0.6x,
a slew cap relative to the reference luminance so no frame moves the drive by more than a
bounded fraction of the sun's recent brightness (a full off-on-off cycle cannot complete in
under 1.6 FadeTime), and adaptive damping: direction reversals of the raw target, measured as
displacement from an anchor so the verdict does not depend on frame rate, slow the filter
above a dead zone. One reversal (an ordinary reveal) costs nothing; a fence-post train settles
to the mean coverage within a few crossings. The drive snaps to exact zero once the target is
black, because a half-float target pins a geometric decay at a denormal.

**Settings.** `RenderLensFlareOcclusionRadius` and `RenderLensFlareOcclusionTaps` are
replaced by `RenderLensFlareOcclusionScale` (multiple of the sun disc, 0.25-2, default 1)
and `RenderLensFlareFadeTime` (0.1-1 s, default 0.35), in `settings_alchemy.xml`, the Looks
whitelist, the three bundled Looks and the Lightbox Occlusion rows (Size, Fade). The
shader derives every rate from the one FadeTime uniform and is the declared source of truth;
`scripts/content_tools/check_lens_flare_state.py` mirrors it statement for statement and is
the regression test that chose the constants.

## Numbers (from the script)

| | |
|---|---|
| step rise 10-90% / fall 90-10% at FadeTime 0.35 | 0.333 s / 0.200 s, no overshoot, frame-rate independent within 0.016 |
| residual swing after 1 / 2 / 3 / 5 / 8 Hz occlusion | 0.34 / 0.11 / 0.07 / 0.05 / 0.04 of full scale |
| 2 Hz fence with 0.05-0.2 s edge crossings, 30-144 fps | damped at every rate, spread across rates 0.001 |
| hard bound from the slew alone | 1.79 full cycles per second |
| kernel: unoccluded drive vs centre texel; half-plane bias std / worst; max tap share | 0.978; 0.015 / 0.036; 3.1% |
| thin poles, 0.25 / 0.5 / 1 / 2 disc radii | 59% / 29% / 3% / 0% of the drive |
| sun behind needles, still camera / drifting camera | 0 change per frame / 0.5% per frame after the filter |

## Verification

- Simulation: 0 failures. Offline GLSL: every assembly of the touched shaders at
  `#version 400` and `420`, with and without `REVERSE_Z`, plus a reserved-word scan of the
  code lines (glslangValidator does not enforce the reserved list; `packed` got through it
  once).
- `alchemy-bin` Release: 0 errors, 0 warnings in the touched files. ctest 139/139 on the
  committed state.
- In world, on Windows: no flicker through fences, foliage, avatar orbits, or the needle
  scene that had still flickered mid-branch.

---

## Checklist

Please ensure the following before requesting review:

- [x] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Documentation has been updated if needed.
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

- The fourth commit is a review fix pass (fifteen findings, including the reserved word, a
  dead material-preview gate and a frame-rate-dependent step detector) plus the still-camera
  needle flicker. Its message carries the detail.
- Merge overlap: the lens-effects branch inserts code immediately after the flare block in
  `colorCorrect` and in `createLUTBuffers` / `renderFinalize`; expect insertion-point
  conflicts only.
- A Look saved before the settings swap carries the old keys and leaves Size and Fade
  untouched when applied; bundled Looks are updated, but seeding is once per name, so an
  existing install keeps its copies.
- The tiled high-resolution snapshot fallback advances the filter once per tile, as every
  other screen-space pass there already is.
- Only Windows has been run in world. The GL 4.1 path is validated offline, not on Apple
  hardware: every touched shader compiles at `#version 400`, a scan of all 237 shaders finds
  no reserved-word identifier outside the CAS and FXAA vendor headers' inactive sections,
  and the one texture read in non-uniform control flow uses an explicit level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)