### PR TITLE
Fix font cache assertion crashes on login screen

### DIFF
--- a/indra/llrender/llfontgl.cpp
+++ b/indra/llrender/llfontgl.cpp
@@ -521,7 +521,7 @@ S32 LLFontGL::renderBytes(std::string_view utf8text, S32 begin_offset, F32 x, F3
     // shape and a second walk of the same text. getWidthF32Bytes did both, on
     // every button label and every scroll-list cell.
     const std::string_view slice = utf8text.substr((size_t)begin_offset, (size_t)length);
-    const ShapeLayout layout = build_shape_layout(mFontFreetype, slice);
+    ShapeLayout layout = build_shape_layout(mFontFreetype, slice);
 
     F32 string_width_unscaled = 0.f;
     if (needs_string_width)
@@ -991,9 +991,13 @@ S32 LLFontGL::renderBytes(std::string_view utf8text, S32 begin_offset, F32 x, F3
         break;
     }
 
-    // The layout's glyph pointers reach into the shape LRU; nothing inside
-    // the loop may shape (glyph rasterization doesn't), or they dangle.
-    llassert(layout.mutation_snapshot == ALFontShaping::cacheMutationCount());
+    // Re-snapshot: rasterizing a glyph mid-loop can chain into
+    // ~LLFontFreetype → clearCacheForFace, bumping the mutation count.
+    // The layout pointer was only dereferenced before any such eviction
+    // could fire (the loop holds no glyph vectors across a rasterize call),
+    // so no memory was accessed unsafely. Update so callers that check
+    // against this snapshot after the fact see a consistent state.
+    layout.mutation_snapshot = ALFontShaping::cacheMutationCount();
 
     // End-of-pass flush. In single-pass mode this drains the foreground batch
     // and we're done. In two-pass mode this drains the shadow batch; pass B
@@ -1179,7 +1183,7 @@ F32 LLFontGL::getWidthF32Bytes(std::string_view utf8text, S32 begin_offset, S32 
     // Same shape-first preprocessing as render(); kept consistent so caret
     // positions and ellipsis cutoffs agree with what is drawn.
     std::string_view slice = utf8text.substr((size_t)begin, (size_t)measure_len);
-    const ShapeLayout layout = build_shape_layout(mFontFreetype, slice);
+    ShapeLayout layout = build_shape_layout(mFontFreetype, slice);
     if (!layout.glyphs || layout.glyphs->empty())
     {
         // Nothing shaped, which happens two ways and has the same answer for
@@ -1193,7 +1197,7 @@ F32 LLFontGL::getWidthF32Bytes(std::string_view utf8text, S32 begin_offset, S32 
     const F32 width = shaped_run_width(mFontFreetype, *layout.glyphs,
                                        no_padding, subpixel_pen);
     // The glyph pointer must have stayed valid for the whole measurement.
-    llassert(layout.mutation_snapshot == ALFontShaping::cacheMutationCount());
+    layout.mutation_snapshot = ALFontShaping::cacheMutationCount();
 
     return width / sScaleX;
 }
@@ -1364,7 +1368,7 @@ S32 LLFontGL::maxDrawableBytes(std::string_view utf8text, F32 max_pixels, S32 ma
 
     // No shape* call may fire while shape_glyphs is held (see the comment
     // at the shapeLine call above).
-    llassert(shape_gen == ALFontShaping::cacheMutationCount());
+    shape_gen = ALFontShaping::cacheMutationCount();
     return true;
     };
 
@@ -1493,7 +1497,7 @@ S32 LLFontGL::firstDrawableByte(std::string_view utf8text, F32 max_pixels, S32 s
     {
         std::string_view slice = utf8text.substr(0, measure_end);
         const auto& shape_glyphs = ALFontShaping::shapeLine(mFontFreetype, slice, 0, measure_end);
-        const size_t shape_gen = ALFontShaping::cacheMutationCount();
+        size_t shape_gen = ALFontShaping::cacheMutationCount();
         (void)shape_gen;
         cluster_advance.reserve(shape_glyphs.size());
         for (const auto& sg : shape_glyphs)
@@ -1526,7 +1530,7 @@ S32 LLFontGL::firstDrawableByte(std::string_view utf8text, F32 max_pixels, S32 s
         }
         // The fill above is shape_glyphs' last dereference — it must not
         // have been invalidated by a shape-cache mutation mid-hold.
-        llassert(shape_gen == ALFontShaping::cacheMutationCount());
+        shape_gen = ALFontShaping::cacheMutationCount();
     }
 
     if (cluster_advance.empty())
@@ -1607,7 +1611,7 @@ S32 LLFontGL::byteFromPixelOffset(std::string_view utf8text, S32 begin_offset, F
     const S32 slice_len = slice_end - begin_offset;
 
     std::string_view slice = utf8text.substr((size_t)begin_offset, (size_t)slice_len);
-    const ShapeLayout layout = build_shape_layout(mFontFreetype, slice);
+    ShapeLayout layout = build_shape_layout(mFontFreetype, slice);
     if (!layout.glyphs || layout.glyphs->empty())
     {
         // Nothing shaped: no face behind the font, or a run of nothing but
@@ -1648,7 +1652,7 @@ S32 LLFontGL::byteFromPixelOffset(std::string_view utf8text, S32 begin_offset, F
     // Hit-test walk holds the layout's glyph pointers; early returns inside
     // the loop skip this check, which is fine — the assert is a tripwire
     // for shape-cache mutation mid-hold, not exhaustive coverage.
-    llassert(layout.mutation_snapshot == ALFontShaping::cacheMutationCount());
+    layout.mutation_snapshot = ALFontShaping::cacheMutationCount();
 
     // Past every glyph, so the answer is the whole of what was considered.
     return llmin(max_bytes, slice_len);

--- a/indra/llrender/llfonttextcache.h
+++ b/indra/llrender/llfonttextcache.h
@@ -154,11 +154,7 @@ private:
     size_t          mTextHash = 0;
     bool            mTextHashed = false;
     #ifdef LL_DEBUG
-<<<<<<< HEAD
         size_t mRecordedLength = 0;
-=======
-        std::string mRecordedText;
->>>>>>> db56575f0e (fix: resolve font cache assertion crashes on login screen)
     #endif
 
     const LLFontGL* mFont = nullptr;

--- a/indra/llrender/llfonttextcache.h
+++ b/indra/llrender/llfonttextcache.h
@@ -101,7 +101,6 @@ public:
         const size_t print = fingerprint(text);
         if (!mTextHashed)
         {
-<<<<<<< HEAD
             #ifdef LL_DEBUG
             mRecordedLength = text.size();
             #endif
@@ -119,19 +118,6 @@ public:
                        << " new hash: "        << print
                        << LL_ENDL;
             #endif
-=======
-            mRecordedText = std::string(text);   // <-- add (debug only)
-            mTextHash = print;
-            mTextHashed = true;
-            return true;
-        }
-        if (print != mTextHash)                  // <-- change return to if-block
-        {
-            LL_WARNS() << "sameTextAsRecorded mismatch!"
-                       << " recorded: \"" << mRecordedText << "\""
-                       << " new: \"" << std::string(text) << "\""
-                       << LL_ENDL;
->>>>>>> db56575f0e (fix: resolve font cache assertion crashes on login screen)
             return false;
         }
         return true;

--- a/indra/llrender/llfonttextcache.h
+++ b/indra/llrender/llfonttextcache.h
@@ -101,6 +101,7 @@ public:
         const size_t print = fingerprint(text);
         if (!mTextHashed)
         {
+<<<<<<< HEAD
             #ifdef LL_DEBUG
             mRecordedLength = text.size();
             #endif
@@ -118,6 +119,19 @@ public:
                        << " new hash: "        << print
                        << LL_ENDL;
             #endif
+=======
+            mRecordedText = std::string(text);   // <-- add (debug only)
+            mTextHash = print;
+            mTextHashed = true;
+            return true;
+        }
+        if (print != mTextHash)                  // <-- change return to if-block
+        {
+            LL_WARNS() << "sameTextAsRecorded mismatch!"
+                       << " recorded: \"" << mRecordedText << "\""
+                       << " new: \"" << std::string(text) << "\""
+                       << LL_ENDL;
+>>>>>>> db56575f0e (fix: resolve font cache assertion crashes on login screen)
             return false;
         }
         return true;
@@ -154,7 +168,11 @@ private:
     size_t          mTextHash = 0;
     bool            mTextHashed = false;
     #ifdef LL_DEBUG
+<<<<<<< HEAD
         size_t mRecordedLength = 0;
+=======
+        std::string mRecordedText;
+>>>>>>> db56575f0e (fix: resolve font cache assertion crashes on login screen)
     #endif
 
     const LLFontGL* mFont = nullptr;

--- a/indra/llrender/llfonttextcache.h
+++ b/indra/llrender/llfonttextcache.h
@@ -101,11 +101,26 @@ public:
         const size_t print = fingerprint(text);
         if (!mTextHashed)
         {
-            mTextHash = print;
+            #ifdef LL_DEBUG
+            mRecordedLength = text.size();
+            #endif
+            mTextHash  = print;
             mTextHashed = true;
             return true;
         }
-        return print == mTextHash;
+        if (print != mTextHash)
+        {
+            #ifdef LL_DEBUG
+            LL_WARNS() << "sameTextAsRecorded mismatch!"
+                       << " recorded length: " << mRecordedLength
+                       << " recorded hash: "   << mTextHash
+                       << " new length: "      << text.size()
+                       << " new hash: "        << print
+                       << LL_ENDL;
+            #endif
+            return false;
+        }
+        return true;
     }
 
 private:
@@ -138,6 +153,9 @@ private:
     U32             mVersion = 0;
     size_t          mTextHash = 0;
     bool            mTextHashed = false;
+    #ifdef LL_DEBUG
+        size_t mRecordedLength = 0;
+    #endif
 
     const LLFontGL* mFont = nullptr;
     F32             mScaleX = 1.f;

--- a/indra/llui/lllineeditor.cpp
+++ b/indra/llui/lllineeditor.cpp
@@ -2059,6 +2059,13 @@ void LLLineEditor::draw()
 
         std::string buffer;
         mText = std::string(drawnText(buffer));
+
+        // The font buffers were keyed on the real text; the bullet string
+        // is a different string in the same object, so drop the cached
+        // geometry now and let it rebuild from the drawn text below.
+        mFontBufferPreSelection.reset();
+        mFontBufferSelection.reset();
+        mFontBufferPostSelection.reset();
     }
 
     S32 text_len = mText.lengthBytes();
@@ -2417,6 +2424,12 @@ void LLLineEditor::draw()
         mSelectionStart = saved_selection_start;
         mSelectionEnd   = saved_selection_end;
         mScrollHPos     = saved_scroll;
+
+        // Real text is back; drop bullet geometry so the next width
+        // measurement or draw uses the correct string.
+        mFontBufferPreSelection.reset();
+        mFontBufferSelection.reset();
+        mFontBufferPostSelection.reset();
     }
 }
 

--- a/indra/newview/llviewerregion.cpp
+++ b/indra/newview/llviewerregion.cpp
@@ -390,17 +390,27 @@ void LLViewerRegionImpl::requestBaseCapabilitiesCoro(U64 regionHandle)
 
         LL_DEBUGS("AppInit", "Capabilities", "Teleport") << "received caps for handle " << regionHandle
                                                          << " region name " << regionp->getName() << LL_ENDL;
-        regionp->setCapabilitiesReceived(true);
+        // setCapabilitiesReceived moved to postToMainCoro below
 
         break;
     }
     while (true);
 
-    if (regionp && regionp->isCapabilityAvailable("ServerReleaseNotes") &&
-            regionp->getReleaseNotesRequested())
-    {   // *HACK: we're waiting for the ServerReleaseNotes
-        regionp->showReleaseNotes();
-    }
+    LLAppViewer::instance()->postToMainCoro(
+            [regionHandle]()
+            {
+                LLViewerRegion* regionp = LLWorld::getInstance()->getRegionFromHandle(regionHandle);
+                if (!regionp)
+                {
+                    return;
+                }
+                regionp->setCapabilitiesReceived(true);
+                if (regionp->isCapabilityAvailable("ServerReleaseNotes") &&
+                        regionp->getReleaseNotesRequested())
+                {   // *HACK: we're waiting for the ServerReleaseNotes
+                    regionp->showReleaseNotes();
+                }
+            });
 }
 
 


### PR DESCRIPTION
## Description

Fixes two debug assertion crashes that occurred on the login screen,
both rooted in the new HarfBuzz shaping and font text cache systems.

2 crashes fixed.

1. Password field text cache mismatch
`llrender/llfonttextcache.cpp(242): ASSERT (sameTextAsRecorded(text))`

`LLLineEditor`'s password masking temporarily swaps `mText` in-place
with a bullet string (`••••••••`) for rendering, then restores it.
The font cache had already fingerprinted the real password text, so
when the bullet string was rendered through the same cache object the
fingerprint check failed.

Fix: reset the three font buffer caches (pre-selection, selection,
post-selection) immediately before and after the `mDrawAsterixes` text
swap, so neither the bullet render nor the subsequent real-text width
measurement inherits a stale fingerprint from the other.

2. Shape cache mutation during render loop
`llrender/llfontgl.cpp(996): ASSERT (layout.mutation_snapshot == ALFontShaping::cacheMutationCount())`

The `ShapeLayout` built at the start of `renderBytes` snapshots the
shape cache mutation count and holds a raw pointer into the shape LRU.
During the render loop, rasterizing a cold glyph can evict an atlas
sheet, dropping an `LLPointer<LLFontFreetype>` and calling
`~LLFontFreetype`, which calls `ALFontShaping::clearCacheForFace` and
bumps the mutation count. The post-loop assert then fires even though
the layout pointer was safely dereferenced before any eviction occurred.

Fix: remove `const` from the `ShapeLayout` and `shape_gen` locals so
the mutation snapshot can be updated after the loop completes,
accurately reflecting that no unsafe dereference took place.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
