### PR TITLE
render: guard generateImpostor against degenerate fov/aspect

### DIFF
--- a/indra/newview/pipeline.cpp
+++ b/indra/newview/pipeline.cpp
@@ -12546,12 +12546,31 @@ void LLPipeline::generateImpostor(LLVOAvatar* avatar, bool preview_avatar, bool 
         tdim.mV[0] = half_height.dot3(left).getF32();
         tdim.mV[1] = half_height.dot3(up).getF32();
 
-        gGL.matrixMode(LLRender::MM_PROJECTION);
-        gGL.pushMatrix();
 
         F32 distance = (pos-camera.getOrigin()).length();
         F32 fov = atanf(tdim.mV[1]/distance)*2.f*RAD_TO_DEG;
         F32 aspect = tdim.mV[0]/tdim.mV[1];
+
+        // Guard against degenerate geometry: the avatar's bounding box can project
+        // to zero in one or both axes (collapsed extents, extreme distance, or a
+        // lookAt singularity when the avatar is directly above/below the camera).
+        // fov==0 or non-finite aspect both produce an unusable projection matrix
+        // and assert-crash inside glm::perspectiveRH_NO.
+        if (fov <= 0.f || !std::isfinite(aspect) || aspect <= 0.f)
+        {
+            LL_WARNS_ONCE("AvatarRenderPipeline") << "generateImpostor: degenerate fov/aspect for avatar "
+                << avatar->getID() << " (fov=" << fov << " aspect=" << aspect
+                << " distance=" << distance << " tdim=" << tdim.mV[0] << "," << tdim.mV[1]
+                << ") -- skipping impostor bake this frame" << LL_ENDL;
+            popRenderTypeMask();
+            sUseOcclusion   = occlusion;
+            sShadowRender   = saved_shadow_render;
+            sImpostorRender = saved_impostor_render;
+            return;
+        }
+
+        gGL.matrixMode(LLRender::MM_PROJECTION);
+        gGL.pushMatrix();
 
         // Clip planes bracketing the subject instead of a hardcoded 1..256.
         //


### PR DESCRIPTION
## Description

When an avatar's spatial extents project to zero in the camera's up axis (collapsed bounding box, extreme distance, or a lookAt singularity when the avatar is directly above or below the camera), tdim.mV[1] is zero. This produces fov=0 and aspect=NaN, which assert-crash inside glm::perspectiveRH_NO before the perspective matrix is written.

Add a finite/positive check on fov and aspect before the GL matrix push. On failure, restore pushRenderTypeMask, sUseOcclusion, sShadowRender and sImpostorRender and return early. Move the MM_PROJECTION pushMatrix to after the guard so no pop is needed on the early-out path and the normal path has exactly one push.

Fixes a reproducible crash when impostoring a distant avatar (>3km) while the viewer window is in the background.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
