### PR TITLE
fix: null-check getOctreeNode()

### DIFF
--- a/indra/newview/llspatialpartition.cpp
+++ b/indra/newview/llspatialpartition.cpp
@@ -1131,8 +1131,9 @@ public:
     {
         LLSpatialGroup* group = (LLSpatialGroup*)base_group;
 
-        if (group->getOctreeNode()->getParent() &&  //never occlusion cull the root node
-            LLPipeline::sUseOcclusion &&            //ignore occlusion if disabled
+        if (group->getOctreeNode() &&               // ← add this
+            group->getOctreeNode()->getParent() &&
+            LLPipeline::sUseOcclusion &&
             group->isOcclusionState(LLSpatialGroup::OCCLUDED))
         {
             return true;
@@ -1208,9 +1209,10 @@ public:
     {
         LLSpatialGroup* group = (LLSpatialGroup*)base_group;
 
-        if (mResult || //already found a node, don't check any more
-            (group->getOctreeNode()->getParent() && //never occlusion cull the root node
-             LLPipeline::sUseOcclusion &&           //ignore occlusion if disabled
+        if (mResult ||
+            (group->getOctreeNode() &&              // ← add this
+             group->getOctreeNode()->getParent() &&
+             LLPipeline::sUseOcclusion &&
              group->isOcclusionState(LLSpatialGroup::OCCLUDED)))
         {
             return true;


### PR DESCRIPTION
## Description

LLOctreeCullVisExtents::earlyFail and LLOctreeCullDetectVisible::earlyFail both called getOctreeNode()->getParent() without first checking that getOctreeNode() is non-null. When a spatial group's octree node has been removed (mOctreeNode set to null) the group itself can remain alive and be reached during traversal, causing a SIGSEGV on the getParent() call.

LLOctreeCull::earlyFail already guarded against this correctly. Bring the other two implementations in line with the same null check.

Fixes a crash in LLPipeline::getVisibleExtents during shadow generation.

## Related Issues

- [ ] **Please link to a relevant GitHub issue for additional context.**
  - **Bug Fix:** Link to an issue that includes reproduction steps and testing guidance.
  - **Feature/Enhancement:** Link to an issue with a write-up, rationale, and requirements.

Issue Link: <!-- e.g., closes #123 or relates to #456 -->

---

## Checklist

Please ensure the following before requesting review:

- [ ] I have provided a clear title and detailed description for this pull request.
- [ ] If useful, I have included media such as screenshots and video to show off my changes.
- [ ] I have tested the changes locally and verified they work as intended.
- [ ] All new and existing tests pass.
- [ ] Code follows the project's style guidelines.
- [ ] Documentation has been updated if needed.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).

---

## Additional Notes

<!--
Add any other information, screenshots, or suggestions for reviewers here.
-->
