### PR TITLE
Notify waiting objects when mesh header retries are exhausted

### DIFF
--- a/indra/newview/llmeshrepository.cpp
+++ b/indra/newview/llmeshrepository.cpp
@@ -1235,7 +1235,17 @@ void LLMeshRepoThread::run()
                     }
                     else
                     {
-                        LL_DEBUGS() << "mHeaderReqQ failed: " << req.mMeshParams << LL_ENDL;
+                        // too many fails -- can't get the header so none of the LODs will
+                        // be available either.  Without this, objects waiting on this
+                        // header never learn it's gone and stay at their placeholder
+                        // shape forever (mirrors LLMeshHeaderHandler::processFailure).
+                        LL_WARNS() << "mHeaderReqQ failed too many times: " << req.mMeshParams << " , skip" << LL_ENDL;
+
+                        LLMutexLock lock(mLoadedMutex);
+                        for (int i = 0; i < LLVolumeLODGroup::NUM_LODS; ++i)
+                        {
+                            mUnavailableQ.push_back(LODRequest(req.mMeshParams, i));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description

In `LLMeshRepoThread::run()`, the header-fetch loop silently dropped requests on final retry exhaustion (`LL_DEBUGS() << "mHeaderReqQ failed: " << req.mMeshParams;`), unlike the LOD and skin loops right next to it which push into `mUnavailableQ` on the identical exhaustion condition.

Any `LLVOVolume` waiting on that mesh's header never received `notifyMeshLoaded` or a forced fallback to an alternative LOD, leaving it stuck at its placeholder shape permanently with no further retry.

`fetchMeshHeader()` returns `false` when the local HTTP layer refuses to enqueue the request due to congestion. While rare during quiet scenes, this is common immediately following a teleport into a crowded region when a large batch of objects arrives simultaneously and hits the concurrent request cap—causing mesh objects to remain unrezzed indefinitely.

This patch mirrors `LLMeshHeaderHandler::processFailure()`: when retries are exhausted, all LOD levels for the mesh are pushed onto `mUnavailableQ` so dependent objects fall back instead of waiting forever.

## Related Issues

- Addresses mesh objects permanently failing to rez / stuck at placeholder shapes after region crossings and crowded teleports.

---

## Checklist

- [x] I have provided a clear title and detailed description for this pull request.
- [x] I have tested the changes locally and verified they work as intended.
- [x] All new and existing tests pass.
- [x] Code follows the project's style guidelines.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have reviewed the [contributing guidelines](https://github.com/AlchemyViewer/Alchemy/blob/main/CONTRIBUTING.md).