### PR TITLE
Fix vehicle unseating on region crossings by ignoring outgoing sim kills

### DIFF
--- a/indra/newview/llviewermessage.cpp
+++ b/indra/newview/llviewermessage.cpp
@@ -4027,6 +4027,22 @@ void process_kill_object(LLMessageSystem *mesgsys, void **user_data)
                 }
 // [/SL:KB]
 
+                // Block vehicle / seat kills sent by the outgoing simulator during region crossings
+                if ( regionp && (regionp != gAgent.getRegion()) &&
+                     isAgentAvatarValid() && gAgentAvatarp->isSitting() )
+                {
+                    LLViewerObject* rootp = objectp->getRootEdit();
+                    if (rootp && (gAgentAvatarp->getRoot() == rootp))
+                    {
+                        if (objectp == rootp)
+                        {
+                            LL_INFOS("Avatar") << "Ignoring vehicle kill from outgoing region " << regionp->getName()
+                                << " for seated root object " << rootp->getID() << LL_ENDL;
+                        }
+                        continue;
+                    }
+                }
+
             // Display green bubble on kill
             if ( gShowObjectUpdates )
             {


### PR DESCRIPTION
## Problem
During region crossings, an avatar can be unexpectedly unseated from their vehicle or seat. This occurs when the departing (outgoing) simulator sends a `KillObject` message for the vehicle while the handoff to the new simulator is still in progress. The viewer processes this kill and calls `markDead()`, which forces the avatar to stand up before the new region has taken full ownership.

## Solution
- In `process_kill_object`, check if a `KillObject` packet originates from a non-active region (`regionp != gAgent.getRegion()`) while the avatar is seated on the object or its linkset.
- When detected, ignore the kill from the departing simulator so the vehicle remains alive during the crossing handoff.
- Cache `objectp->getRootEdit()` in a local pointer to avoid redundant tree traversals.
- Only log (`LL_INFOS`) when the linkset root prim is targeted, preventing log spam for complex multi-prim linksets.